### PR TITLE
Remove directory from cmake source file list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@ endforeach()
 
 add_library(gdstk STATIC
     src/cell.cpp
-    src/clipperlib
     src/clipper_tools.cpp
     src/curve.cpp
     src/flexpath.cpp


### PR DESCRIPTION
I am not sure why you don't have this problem, but I can't compile gdstk without this change. I get the following error:

```
  CMake Error at CMakeLists.txt:33 (add_library):                                                                                                                                            
    Cannot find source file:                                                                                                                                                                 
                                                                                                                                                                                             
      src/clipperlib                                                                                                                                                                         
                                                                                                                                                                                             
    Tried extensions .c .C .c++ .cc .cpp .cxx .cu .m .M .mm .h .hh .h++ .hm                                                                                                                  
    .hpp .hxx .in .txx 
```

where it seems `cmake` is interpreting `src/clipperlib` as a source file when it is actually directory. `src/clipperlib/clipperlib.cpp` is included in the list, so the only necessary change was to remove the problematic `src/clipperlib` entry.

I thought it might be a cmake version difference but I tried 3.13 and 3.18 and got the same error.