### PR TITLE
specify minimum `zlib` version in `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ foreach(IT ${LAPACK_LIBRARIES})
     set(PRIVATE_LIBS "${PRIVATE_LIBS} ${IT}")
 endforeach()
 
-find_package(ZLIB REQUIRED)
+find_package(ZLIB 1.2.9 REQUIRED)
 foreach(IT ${ZLIB_LIBRARIES})
     set(PRIVATE_LIBS "${PRIVATE_LIBS} ${IT}")
 endforeach()


### PR DESCRIPTION
According to the `zlib` changelog (see [here](https://zlib.net/ChangeLog.txt)), the `crc32_z` function was introduced in version `1.2.9`. This PR sets the required minimum `zlib` version in `CMakeLists.txt`.