### PR TITLE
Add numpy build requirement in pyproject.toml, per PEP 518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy >= 1.20.0"]
+


### PR DESCRIPTION
Thanks for an excellent library!

This PR is to fix an issue related to https://github.com/heitzmann/gdstk/issues/44; specifically, installing via `pip` in a clean environment fails, because `setup.py` wants to import `numpy`, and it's not installed yet. This is the situation described and resolved by [PEP 518](https://www.python.org/dev/peps/pep-0518).

Adding the `numpy` requirement in `pyproject.toml` (per that PEP) allows `gdstk` to build & install successfully via `pip` even when `numpy` is not yet available in the environment.