### PR TITLE
Clarify behavior of `depth` parameter in `get_*` method documentation

### DIFF
--- a/python/docstrings.cpp
+++ b/python/docstrings.cpp
@@ -2366,7 +2366,8 @@ Args:
       also included in the result.
     depth: If non negative, indicates the number of reference levels
       processed recursively.  A value of 0 will result in no references
-      being visited.
+      being visited.  A value of ``None`` (the default) or a negative int
+      will include all reference levels below the cell.
     layer: If set, only polygons in the defined layer and data type are
       returned.
     datatype: If set, only polygons in the defined layer and data type
@@ -2386,7 +2387,8 @@ Args:
       the created paths.
     depth: If non negative, indicates the number of reference levels
       processed recursively.  A value of 0 will result in no references
-      being visited.
+      being visited.  A value of ``None`` (the default) or a negative int
+      will include all reference levels below the cell.
     layer: If set, only paths in the defined layer and data type are
       returned.
     datatype: If set, only paths in the defined layer and data type are
@@ -2406,7 +2408,8 @@ Args:
       the created labels.
     depth: If non negative, indicates the number of reference levels
       processed recursively.  A value of 0 will result in no references
-      being visited.
+      being visited.  A value of ``None`` (the default) or a negative int
+      will include all reference levels below the cell.
     layer: If set, only labels in the defined layer and text type are
       returned.
     texttype: If set, only labels in the defined layer and text type


### PR DESCRIPTION
I was confused about the default behavior of `get_polygons` and I wanted to contribute a doc clarification here. This is based on my reading of the underlying implementation as well as experimenting with behavior, but _please_ correct me if I'm wrong.