### PR TITLE
Enable more reliable source compilation on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,26 @@ else()
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -DNDEBUG")
 endif()
 
-find_package(ZLIB 1.2.9 REQUIRED)
+find_package(ZLIB 1.2.9)
+if(NOT ZLIB_FOUND)
+    # Check first for header files
+    if(DEFINED ENV{ZLIB_INCLUDE_DIRS})
+        set(ZLIB_INCLUDE_DIRS ENV{ZLIB_INCLUDE_DIRS})
+    else()
+        message(FATAL_ERROR "ZLIB headers were not found, either via find_package or env variable")
+    endif()
+
+    # Use normal library-finding methods first
+    find_library(ZLIB_LIBRARIES zlib)
+    # But give precedence to user-set library path
+    if(DEFINED ENV{ZLIB_LIBRARIES})
+        set(ZLIB_LIBRARIES ENV{ZLIB_LIBRARIES})
+    # This would be set if find_library succedes, e.g. the library is on PATH, but no env-var was set.
+    elseif(NOT ZLIB_LIBRARIES)
+        message(FATAL_ERROR "ZLIB could not be found, either via find_package, find_library, or env variable.")
+    endif()
+endif(NOT ZLIB_FOUND)
+
 foreach(IT ${ZLIB_LIBRARIES})
     set(PRIVATE_LIBS "${PRIVATE_LIBS} ${IT}")
 endforeach()


### PR DESCRIPTION
Windows does not have a standard way to define the location of headers and libraries like Linux. Multiple solutions exist (vcpkg, conan, ...) that attempt to fix this, but they rely on different mechanisms. This PR tries to add a bit more flexibility to this process.

This PR makes it so that a user not using Anaconda (for whatever reason) is still able to successfully compile the library and the Python module. Right now, it's not always the case that `find_package` succedes: e.g. when using `vcpkg` to handle C/C++ dependencies, the linker arguments supplied will make the build fail. I do not think this is a `gdstk` bug, that's why I did not create an issue.

It uses `find_package` by default, so that Linux builds are not affected but on failure to locate the library, two mecahnisms are tried:

1. The user can set `ZLIB_INCLUDE_DIRS` and `ZLIB_LIBRARIES` as as environment variables, and they will be used **if `find_package` fails**. If `ZLIB_INCLUDE_DIRS` is not set, the build will fail.
2. If `ZLIB_LIBRARIES` is not set, then `find_library` will be used, which should scan tha `PATH` variable on Windows for possible
   libraries.
3. The build fails if all these three mechanisms fail, in this order: `find_package`, unset `ZLIB_LIBRARY`, `find_library`.