### PR TITLE
enable testing with `python-3.10`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
     name: Linux test for ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
     name: Windows test for ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
     name: MacOS test for ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Related... `python-3.6` is end-of-life'd. Should `3.6` be removed from testing?

ref: https://www.python.org/dev/peps/pep-0494