### PR TITLE
Clear Cell result arrays after copying to Python lists

### DIFF
--- a/python/cell_object.cpp
+++ b/python/cell_object.cpp
@@ -276,6 +276,8 @@ static PyObject* cell_object_get_polygons(CellObject* self, PyObject* args, PyOb
         poly->owner = obj;
         PyList_SET_ITEM(result, i, (PyObject*)obj);
     }
+
+    array.clear();
     return result;
 }
 
@@ -354,6 +356,9 @@ static PyObject* cell_object_get_paths(CellObject* self, PyObject* args, PyObjec
         path->owner = obj;
         PyList_SET_ITEM(result, i, (PyObject*)obj);
     }
+
+    fp_array.clear();
+    rp_array.clear();
     return result;
 }
 
@@ -414,6 +419,8 @@ static PyObject* cell_object_get_labels(CellObject* self, PyObject* args, PyObje
         label->owner = obj;
         PyList_SET_ITEM(result, i, (PyObject*)obj);
     }
+
+    array.clear();
     return result;
 }
 


### PR DESCRIPTION
While investigating the memory usage of a Python application, I ran across a couple of cases in `cell_object.cpp` where the the result of `Cell::get_*()` methods was not cleared before returning back to Python.

With the changes in this PR, memory usage of the app remains stable, even when calling `cell.get_polygons()`, `cell.get_labels()`, and/or `cell.get_paths()` in a tight loop.