### PR TITLE
Update Python list index in `cell_object_get_paths()`

### DIFF
--- a/python/cell_object.cpp
+++ b/python/cell_object.cpp
@@ -354,7 +354,7 @@ static PyObject* cell_object_get_paths(CellObject* self, PyObject* args, PyObjec
         obj = (RobustPathObject*)PyObject_Init((PyObject*)obj, &robustpath_object_type);
         obj->robustpath = path;
         path->owner = obj;
-        PyList_SET_ITEM(result, i, (PyObject*)obj);
+        PyList_SET_ITEM(result, i + fp_array.count, (PyObject*)obj);
     }
 
     fp_array.clear();

--- a/tests/cell_test.py
+++ b/tests/cell_test.py
@@ -314,12 +314,15 @@ def test_get_paths(tree):
     paths = c3.get_paths()
     assert len(paths) == 12
     assert paths[0].num_paths == 2
+    assert all(p is not None for p in paths)
     paths = c3.get_paths(depth=1)
     assert len(paths) == 6
     assert paths[0].num_paths == 2
+    assert all(p is not None for p in paths)
     paths = c3.get_paths(depth=1, layer=1, datatype=3)
     assert len(paths) == 6
     assert paths[0].num_paths == 1
+    assert all(p is not None for p in paths)
 
 
 def test_get_labels(tree):


### PR DESCRIPTION
Digging through some debugger output related to #76, I found that `cell_object_get_paths()` was not returning all `FlexPath`s if a cell also had one or more `RobustPath`s. This happens because the index given to `PyList_SET_ITEM()` starts over at 0 while iterating through the list of `RobustPath` objects, overwriting the `FlexPath` objects.

A side effect was that the `FlexPath` objects were leaked, as the Python VM did not know about them and so `flexpath_object_dealloc()` was never called.

This PR fixes those issues by adding `fp_array.count` when putting `RobustPath` objects in the return list. I also updated `cell_test.test_get_paths()` to check that no paths are `None`, since the `len()` check did not catch the `NULL` item entries.