### PR TITLE
Clear allocated polygons in `cell_object_area()`

### DIFF
--- a/python/cell_object.cpp
+++ b/python/cell_object.cpp
@@ -136,7 +136,11 @@ static PyObject* cell_object_area(CellObject* self, PyObject* args) {
             if (!area) {
                 PyErr_SetString(PyExc_RuntimeError, "Could not convert area to float.");
                 Py_DECREF(result);
-                array.clear_items();
+                for (uint64_t i = 0; i < array.count; i++) {
+                    array[i]->clear();
+                    free_allocation(array[i]);
+                }
+                array.clear();
                 return NULL;
             }
             PyObject* key = Py_BuildValue("(hh)", get_layer(poly->tag), get_type(poly->tag));
@@ -144,7 +148,11 @@ static PyObject* cell_object_area(CellObject* self, PyObject* args) {
                 PyErr_SetString(PyExc_RuntimeError, "Unable to build key.");
                 Py_DECREF(area);
                 Py_DECREF(result);
-                array.clear_items();
+                for (uint64_t i = 0; i < array.count; i++) {
+                    array[i]->clear();
+                    free_allocation(array[i]);
+                }
+                array.clear();
                 return NULL;
             }
             PyObject* current = PyDict_GetItem(result, key);
@@ -155,7 +163,11 @@ static PyObject* cell_object_area(CellObject* self, PyObject* args) {
                     Py_DECREF(key);
                     Py_DECREF(area);
                     Py_DECREF(result);
-                    array.clear_items();
+                    for (uint64_t i = 0; i < array.count; i++) {
+                        array[i]->clear();
+                        free_allocation(array[i]);
+                    }
+                    array.clear();
                     return NULL;
                 }
                 if (PyDict_SetItem(result, key, sum) < 0) {
@@ -163,7 +175,11 @@ static PyObject* cell_object_area(CellObject* self, PyObject* args) {
                     Py_DECREF(key);
                     Py_DECREF(area);
                     Py_DECREF(result);
-                    array.clear_items();
+                    for (uint64_t i = 0; i < array.count; i++) {
+                        array[i]->clear();
+                        free_allocation(array[i]);
+                    }
+                    array.clear();
                     return NULL;
                 }
                 Py_DECREF(sum);
@@ -173,7 +189,11 @@ static PyObject* cell_object_area(CellObject* self, PyObject* args) {
                     Py_DECREF(key);
                     Py_DECREF(area);
                     Py_DECREF(result);
-                    array.clear_items();
+                    for (uint64_t i = 0; i < array.count; i++) {
+                        array[i]->clear();
+                        free_allocation(array[i]);
+                    }
+                    array.clear();
                     return NULL;
                 }
             }
@@ -186,7 +206,11 @@ static PyObject* cell_object_area(CellObject* self, PyObject* args) {
         for (uint64_t i = 0; i < array.count; i++, poly++) area += (*poly)->area();
         result = PyFloat_FromDouble(area);
     }
-    array.clear_items();
+    for (uint64_t i = 0; i < array.count; i++) {
+        array[i]->clear();
+        free_allocation(array[i]);
+    }
+    array.clear();
     return result;
 }
 

--- a/python/cell_object.cpp
+++ b/python/cell_object.cpp
@@ -136,7 +136,7 @@ static PyObject* cell_object_area(CellObject* self, PyObject* args) {
             if (!area) {
                 PyErr_SetString(PyExc_RuntimeError, "Could not convert area to float.");
                 Py_DECREF(result);
-                array.clear();
+                array.clear_items();
                 return NULL;
             }
             PyObject* key = Py_BuildValue("(hh)", get_layer(poly->tag), get_type(poly->tag));
@@ -144,7 +144,7 @@ static PyObject* cell_object_area(CellObject* self, PyObject* args) {
                 PyErr_SetString(PyExc_RuntimeError, "Unable to build key.");
                 Py_DECREF(area);
                 Py_DECREF(result);
-                array.clear();
+                array.clear_items();
                 return NULL;
             }
             PyObject* current = PyDict_GetItem(result, key);
@@ -155,7 +155,7 @@ static PyObject* cell_object_area(CellObject* self, PyObject* args) {
                     Py_DECREF(key);
                     Py_DECREF(area);
                     Py_DECREF(result);
-                    array.clear();
+                    array.clear_items();
                     return NULL;
                 }
                 if (PyDict_SetItem(result, key, sum) < 0) {
@@ -163,7 +163,7 @@ static PyObject* cell_object_area(CellObject* self, PyObject* args) {
                     Py_DECREF(key);
                     Py_DECREF(area);
                     Py_DECREF(result);
-                    array.clear();
+                    array.clear_items();
                     return NULL;
                 }
                 Py_DECREF(sum);
@@ -173,7 +173,7 @@ static PyObject* cell_object_area(CellObject* self, PyObject* args) {
                     Py_DECREF(key);
                     Py_DECREF(area);
                     Py_DECREF(result);
-                    array.clear();
+                    array.clear_items();
                     return NULL;
                 }
             }
@@ -186,7 +186,7 @@ static PyObject* cell_object_area(CellObject* self, PyObject* args) {
         for (uint64_t i = 0; i < array.count; i++, poly++) area += (*poly)->area();
         result = PyFloat_FromDouble(area);
     }
-    array.clear();
+    array.clear_items();
     return result;
 }
 

--- a/src/array.h
+++ b/src/array.h
@@ -55,16 +55,6 @@ struct Array {
         count = 0;
     }
 
-    void clear_items() {
-        T* item_ptr = items;
-        for (uint64_t i = 0; i < count; i++, item_ptr++) {
-            (*item_ptr)->clear();
-            free_allocation(*item_ptr);
-        }
-
-        clear();
-    }
-
     bool contains(const T item) const {
         T* it = items;
         for (uint64_t j = 0; j < count; j++)

--- a/src/array.h
+++ b/src/array.h
@@ -55,6 +55,16 @@ struct Array {
         count = 0;
     }
 
+    void clear_items() {
+        T* item_ptr = items;
+        for (uint64_t i = 0; i < count; i++, item_ptr++) {
+            (*item_ptr)->clear();
+            free_allocation(*item_ptr);
+        }
+
+        clear();
+    }
+
     bool contains(const T item) const {
         T* it = items;
         for (uint64_t j = 0; j < count; j++)


### PR DESCRIPTION
`cell_object_area()` retrieves a list of polygons with `Cell::get_polygons()` in order to sum their area, and then clears the array. However, unlike most of the other methods in `cell_object.cpp`, it does not hand the polygons back to Python, only the computed result. That means that each polygon object must also be cleared in order to avoid a memory leak.

@heitzmann I'm not quite sure about the best way to write this. Because there are several paths through `cell_object_area()` where the result array must be cleared, I added the `Array::clear_items()` helper, but I don't know if that method fits with how `Array` should be used. Would you prefer to have a loop with `clear()` + `free_allocation()` at each return site?