### PR TITLE
Add sequence check when parsing doubles

### DIFF
--- a/python/parsing.cpp
+++ b/python/parsing.cpp
@@ -74,6 +74,10 @@ static int64_t parse_point_sequence(PyObject* py_polygon, Array<Vec2>& dest, con
 }
 
 static int64_t parse_double_sequence(PyObject* sequence, Array<double>& dest, const char* name) {
+    if (!PySequence_Check(sequence)) {
+        PyErr_Format(PyExc_RuntimeError, "Argument %s must be a sequence.", name);
+        return -1;
+    }
     const int64_t len = PySequence_Length(sequence);
     if (len <= 0) {
         PyErr_Format(PyExc_RuntimeError,


### PR DESCRIPTION
A minor change for clarity here; I noticed that `parse_double_sequence()` doesn't perform a sequence check before checking `PySequence_Length()`, unlike the other `parse_*_sequence()` functions do. If a caller mistakenly provides a non-sequence argument, they may get a surprising error message:

```python
>>> r = gdstk.Repetition(x_offsets=2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Argument x_offsets is a sequence with invalid length (18446744073709551615).
```

Adding a sequence check more accurately identifies the caller's mistake.

```python
>>> r = gdstk.Repetition(x_offsets=2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: Argument x_offsets must be a sequence.
```