### PR TITLE
Increment refcount on cell or raw cell when copying reference

### DIFF
--- a/python/reference_object.cpp
+++ b/python/reference_object.cpp
@@ -110,6 +110,12 @@ static PyObject* reference_object_copy(ReferenceObject* self, PyObject*) {
     result = (ReferenceObject*)PyObject_Init((PyObject*)result, &reference_object_type);
     result->reference = (Reference*)allocate_clear(sizeof(Reference));
     result->reference->copy_from(*self->reference);
+
+    if (result->reference->type == ReferenceType::Cell)
+        Py_INCREF(result->reference->cell->owner);
+    else if (result->reference->type == ReferenceType::RawCell)
+        Py_INCREF(result->reference->rawcell->owner);
+
     result->reference->owner = result;
     return (PyObject*)result;
 }

--- a/tests/reference_test.py
+++ b/tests/reference_test.py
@@ -63,3 +63,29 @@ def test_label_bounding_box():
     bb = ref.bounding_box()
     assert_close(bb, ((x, y), (x, y)))
 
+
+def _create_cell_reference(raw=False):
+    if raw:
+        c = gdstk.RawCell("CELL")
+    else:
+        c = gdstk.Cell("CELL")
+    return gdstk.Reference(c)
+
+
+def _copy_and_set_properties(ref):
+    ref_copy = ref.copy()
+    ref_copy.set_gds_property(101, "test")
+    return ref_copy
+
+
+def test_copy_with_cell():
+    ref_copy = _copy_and_set_properties(_create_cell_reference(raw=False))
+
+    assert ref_copy.get_gds_property(101) == "test"
+    assert ref_copy.cell.name == "CELL"
+
+def test_copy_with_rawcell():
+    ref_copy = _copy_and_set_properties(_create_cell_reference(raw=True))
+
+    assert ref_copy.get_gds_property(101) == "test"
+    assert ref_copy.cell.name == "CELL"


### PR DESCRIPTION
Currently, `reference_object_copy()` does not increment the Python reference count on the `Cell` or `RawCell` object that it points to. If Python code copies a reference, and the original reference is dealloced, the copied reference may be left with a dangling cell pointer. Accessing `reference_copy.cell` then segfaults.

This PR adds a test that demonstrates the problem for references to both cells and rawcells, and `Py_INCREF()` calls in `reference_object_copy()` to prevent premature cell deallocation.