### PR TITLE
Reference's `x_reflection` property could not be set to `false` from Python

### DIFF
--- a/python/reference_object.cpp
+++ b/python/reference_object.cpp
@@ -343,9 +343,8 @@ int reference_object_set_x_reflection(ReferenceObject* self, PyObject* arg, void
     if (test < 0) {
         PyErr_SetString(PyExc_RuntimeError, "Unable to determine truth value.");
         return -1;
-    } else if (test > 0) {
+    } else
         self->reference->x_reflection = test > 0;
-    }
     return 0;
 }
 

--- a/tests/reference_test.py
+++ b/tests/reference_test.py
@@ -24,6 +24,18 @@ def test_noreference():
     assert ref.x_reflection == True
 
 
+def test_x_reflection():
+    c = gdstk.Cell("test")
+    ref = gdstk.Reference(c, x_reflection=False)
+    assert not ref.x_reflection
+
+    ref.x_reflection = True
+    assert ref.x_reflection
+
+    ref.x_reflection = False
+    assert not ref.x_reflection
+
+
 def test_empty():
     name = "ca_empty"
     c = gdstk.Cell(name)


### PR DESCRIPTION
`reference_object_set_x_reflection()` checks the value returned from `PyObject_IsTrue()` to see if it is `> 0` before passing it through to `self->reference->x_reflection`. However, `PyObject_IsTrue()` [returns `0` when the object is falsey](https://docs.python.org/3/c-api/object.html#c.PyObject_IsTrue), so a Python caller could never successfully set an existing reference with `x_reflection=True` to `x_reflection=False`.

In this PR, I've added a test to demonstrate the problem and removed the extra check, to fix it.

I took a quick peek at other uses of `PyObject_IsTrue()` and they all look fine AFAICS; for example, [`label_object_set_x_reflection()`](https://github.com/heitzmann/gdstk/blob/5ffff209791b8af48d7997958d23448baec2ae66/python/label_object.cpp#L382-L390) is identical to the changed code here.
