### PR TITLE
Clear repetition object on Python dealloc

### DIFF
--- a/python/repetition_object.cpp
+++ b/python/repetition_object.cpp
@@ -34,7 +34,12 @@ static PyObject* repetition_object_str(RepetitionObject* self) {
     return PyUnicode_FromString(buffer);
 }
 
-static void repetition_object_dealloc(RepetitionObject* self) { PyObject_Del(self); }
+static void repetition_object_dealloc(RepetitionObject* self) {
+    Repetition repetition = self->repetition;
+    repetition.clear();
+
+    PyObject_Del(self);
+}
 
 static int repetition_object_init(RepetitionObject* self, PyObject* args, PyObject* kwds) {
     PyObject* spacing_obj = Py_None;


### PR DESCRIPTION
`repetition_object_dealloc()` currently does not call `Repetition::clear()` before returning. If a Python caller creates a repetition object of type `RepetitionType::Explicit`, `RepetitionType::ExplicitX`, or `RepetitionType::ExplicitY`, memory allocated to the `Repetition`'s `offsets` or `coords` members will be leaked.

I've added the `::clear()` call in this PR, which fixes the memory leak in my local testing.