### PR TITLE
inline gdswriter_init

### DIFF
--- a/src/gdswriter.h
+++ b/src/gdswriter.h
@@ -53,7 +53,7 @@ struct GdsWriter {
 // timestamp, which can be specified by the caller or left NULL, in which case
 // the current time will be used.  If not NULL, any errors will be reported
 // through error_code.
-GdsWriter gdswriter_init(const char* filename, const char* library_name, double unit,
+inline GdsWriter gdswriter_init(const char* filename, const char* library_name, double unit,
                          double precision, uint64_t max_points, tm* timestamp,
                          ErrorCode* error_code) {
     GdsWriter result = {NULL, unit, precision, max_points};


### PR DESCRIPTION
Since implementation is in header file, this need to be inlined, otherwise it will possibly break the one definition rule.