### PR TITLE
Fix ref counting in `Reference::apply_repetition`

### DIFF
--- a/python/reference_object.cpp
+++ b/python/reference_object.cpp
@@ -368,6 +368,11 @@ static PyObject* reference_object_apply_repetition(ReferenceObject* self, PyObje
         obj = (ReferenceObject*)PyObject_Init((PyObject*)obj, &reference_object_type);
         obj->reference = array[i];
         array[i]->owner = obj;
+        if (array[i]->type == ReferenceType::Cell) {
+            Py_INCREF(array[i]->cell->owner);
+        } else if (array[i]->type == ReferenceType::RawCell) {
+            Py_INCREF(array[i]->rawcell->owner);
+        }
         PyList_SET_ITEM(result, i, (PyObject*)obj);
     }
     array.clear();


### PR DESCRIPTION
The reference count of the referenced (raw) cells needs to be increased for each created Reference. Otherwise, DECREF in reference_object_dealloc is not balanced.

This issue becomes visible when the return value of `apply_repetition` is not assigned, e.g. by calling `ref.apply_repetition()` instead of `out = ref.apply_repetition()`, as this results in immediate deallocation of the returned list and its elements.