### PR TITLE
ci: Add GitHub action for building & publishing PyPI packages

### DIFF
--- a/.github/workflows/pypi-packages.yml
+++ b/.github/workflows/pypi-packages.yml
@@ -1,0 +1,74 @@
+name: Build & publish PyPI packages
+
+on:
+  push:
+    tags:
+      - v[0-9]+.**
+
+jobs:
+  build-sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - name: Building source package
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --sdist
+      - uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: "dist/*"
+
+  build-win64-wheels:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip wheel oldest-supported-numpy
+          python -m pip install conan ninja
+          conan install zlib/1.2.13@ -s compiler.version=16 -g cmake_paths
+      - name: Build Python ${{ matrix.python-version }} wheel
+        run: |
+          python setup.py bdist_wheel
+        env:
+          CMAKE_GENERATOR: "Ninja"
+          CMAKE_TOOLCHAIN_FILE: "conan_paths.cmake"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: "dist/*.whl"
+
+  pypi-publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs: [build-sdist, build-win64-wheels]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: packages
+        path: dist
+    - name: List of produced packages
+      run: |
+        du -bh dist/*
+    - name: Test PyPI publish
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        skip_existing: true
+    - name: PyPI publish
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Action for building `gdstk` source and win64 wheel packages for each new version-like-tag, and for uploading the packages to the PyPI repository.

Windows x64 build strategy:
Building the gdstk library requires zlib, which is being fetched as a pre-built dependency using `conan`. For the time being, we're explicitly fetching a zlib package built with MSVC 2019 in order to avoid building the not-yet-available MSVC 2022 zlib package on every job.

PyPI publish:
The PyPI publish step requires the two GitHub Action secret authorization tokens `TEST_PYPI_API_TOKEN` and `PYPI_API_TOKEN`.