### PR TITLE
Allow reading compressed gzip files and reading from istream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(gdstk STATIC
     src/libqhull_r/user_r.c
     src/libqhull_r/rboxlib_r.c
     src/libqhull_r/userprintf_rbox_r.c
+    src/zfstream/zfstream.cc
 )
 
 target_include_directories(gdstk PRIVATE ${ZLIB_INCLUDE_DIRS})

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -880,7 +880,7 @@ ErrorCode Cell::write_svg(const char* filename, double scaling, uint32_t precisi
 
     FILE* out = fopen(filename, "w");
     if (out == NULL) {
-        fputs("[GDSTK] Unable to open file for SVG output.\n", stderr);
+        if (error_logger) fputs("[GDSTK] Unable to open file for SVG output.\n", error_logger);
         return ErrorCode::OutputFileOpenError;
     }
 

--- a/src/clipper_tools.cpp
+++ b/src/clipper_tools.cpp
@@ -161,7 +161,8 @@ static void link_holes(ClipperLib::PolyNode* node, ErrorCode& error_code) {
         }
 
         if (p_closest == p_end) {
-            fprintf(stderr, "[GDSTK] Unable to link hole in boolean operation.\n");
+            if (error_logger)
+                fprintf(error_logger, "[GDSTK] Unable to link hole in boolean operation.\n");
             error_code = ErrorCode::BooleanError;
         } else {
             ClipperLib::IntPoint p_new(xnew, hole_min->Y);

--- a/src/gdsii.cpp
+++ b/src/gdsii.cpp
@@ -40,16 +40,20 @@ double gdsii_real_to_double(uint64_t real) {
 
 ErrorCode gdsii_read_record(FILE* in, uint8_t* buffer, uint64_t& buffer_count) {
     if (buffer_count < 4) {
-        fputs("[GDSTK] Insufficient memory in buffer.\n", stderr);
+        if (error_logger) fputs("[GDSTK] Insufficient memory in buffer.\n", error_logger);
         return ErrorCode::InsufficientMemory;
     }
     uint64_t read_length = fread(buffer, 1, 4, in);
     if (read_length < 4) {
         DEBUG_PRINT("Read bytes (expected 4): %" PRIu64 "\n", read_length);
         if (feof(in) != 0) {
-            fputs("[GDSTK] Unable to read input file. End of file reached unexpectedly.\n", stderr);
+            if (error_logger)
+                fputs("[GDSTK] Unable to read input file. End of file reached unexpectedly.\n",
+                      error_logger);
         } else {
-            fprintf(stderr, "[GDSTK] Unable to read input file. Error number %d\n.", ferror(in));
+            if (error_logger)
+                fprintf(error_logger, "[GDSTK] Unable to read input file. Error number %d\n.",
+                        ferror(in));
         }
         buffer_count = read_length;
         return ErrorCode::InputFileError;
@@ -58,7 +62,7 @@ ErrorCode gdsii_read_record(FILE* in, uint8_t* buffer, uint64_t& buffer_count) {
     const uint32_t record_length = *((uint16_t*)buffer);
     if (record_length < 4) {
         DEBUG_PRINT("Record length should be at least 4. Found %" PRIu32 "\n", record_length);
-        fputs("[GDSTK] Invalid or corrupted GDSII file.\n", stderr);
+        if (error_logger) fputs("[GDSTK] Invalid or corrupted GDSII file.\n", error_logger);
         buffer_count = read_length;
         return ErrorCode::InvalidFile;
     } else if (record_length == 4) {
@@ -66,7 +70,7 @@ ErrorCode gdsii_read_record(FILE* in, uint8_t* buffer, uint64_t& buffer_count) {
         return ErrorCode::NoError;
     }
     if (buffer_count < 4 + record_length) {
-        fputs("[GDSTK] Insufficient memory in buffer.\n", stderr);
+        if (error_logger) fputs("[GDSTK] Insufficient memory in buffer.\n", error_logger);
         buffer_count = read_length;
         return ErrorCode::InsufficientMemory;
     }
@@ -76,9 +80,13 @@ ErrorCode gdsii_read_record(FILE* in, uint8_t* buffer, uint64_t& buffer_count) {
         DEBUG_PRINT("Read bytes (expected %" PRIu32 "): %" PRIu64 "\n", record_length - 4,
                     read_length);
         if (feof(in) != 0) {
-            fputs("[GDSTK] Unable to read input file. End of file reached unexpectedly.\n", stderr);
+            if (error_logger)
+                fputs("[GDSTK] Unable to read input file. End of file reached unexpectedly.\n",
+                      error_logger);
         } else {
-            fprintf(stderr, "[GDSTK] Unable to read input file. Error number %d\n.", ferror(in));
+            if (error_logger)
+                fprintf(error_logger, "[GDSTK] Unable to read input file. Error number %d\n.",
+                        ferror(in));
         }
         return ErrorCode::InputFileError;
     }

--- a/src/gdsii.h
+++ b/src/gdsii.h
@@ -14,6 +14,8 @@ LICENSE file or <http://www.boost.org/LICENSE_1_0.txt>
 #include <stdint.h>
 #include <stdio.h>
 
+#include <iosfwd>
+
 #include "utils.h"
 
 namespace gdstk {
@@ -99,6 +101,8 @@ double gdsii_real_to_double(uint64_t real);
 // buffer must be passed in buffer_count.  On return, the record lenght
 // (including header) is returned in buffer_count.
 ErrorCode gdsii_read_record(FILE* in, uint8_t* buffer, uint64_t& buffer_count);
+
+ErrorCode gdsii_read_record(std::istream& in, uint8_t* buffer, uint64_t& buffer_count);
 
 }  // namespace gdstk
 

--- a/src/gdswriter.h
+++ b/src/gdswriter.h
@@ -66,7 +66,7 @@ inline GdsWriter gdswriter_init(const char* filename, const char* library_name, 
 
     result.out = fopen(filename, "wb");
     if (result.out == NULL) {
-        fputs("[GDSTK] Unable to open GDSII file for output.\n", stderr);
+        fputs("[GDSTK] Unable to open GDSII file for output.\n", error_logger);
         if (error_code) *error_code = ErrorCode::OutputFileOpenError;
         return result;
     }

--- a/src/library.h
+++ b/src/library.h
@@ -14,6 +14,8 @@ LICENSE file or <http://www.boost.org/LICENSE_1_0.txt>
 #include <stdio.h>
 #include <time.h>
 
+#include <iosfwd>
+
 #include "array.h"
 #include "cell.h"
 
@@ -160,6 +162,9 @@ struct LibraryInfo {
 Library read_gds(const char* filename, double unit, double tolerance, const Set<Tag>* shape_tags,
                  ErrorCode* error_code);
 
+Library read_gds(std::istream& in, double unit, double tolerance, const Set<Tag>* shape_tags,
+                 ErrorCode* error_code);
+
 // Read the contents of an OASIS file into a new library.  If unit is not zero,
 // the units in the file are converted (all elements are properly scaled to the
 // desired unit).  The value of tolerance is used as the default tolerance for
@@ -167,6 +172,10 @@ Library read_gds(const char* filename, double unit, double tolerance, const Set<
 // empty, only shapes in those tags will be imported.  If not NULL, any errors
 // will be reported through error_code.
 Library read_oas(const char* filename, double unit,
+                 double tolerance,  // TODO: const Set<Tag>* shape_tags,
+                 ErrorCode* error_code);
+
+Library read_oas(std::istream& is, double unit,
                  double tolerance,  // TODO: const Set<Tag>* shape_tags,
                  ErrorCode* error_code);
 

--- a/src/oasis.h
+++ b/src/oasis.h
@@ -14,6 +14,8 @@ LICENSE file or <http://www.boost.org/LICENSE_1_0.txt>
 #include <stdint.h>
 #include <stdio.h>
 
+#include <iosfwd>
+
 #include "array.h"
 #include "map.h"
 #include "repetition.h"
@@ -147,6 +149,7 @@ enum struct OasisRecord : uint8_t {
 
 struct OasisStream {
     FILE* file;
+    std::istream* stream;
     uint8_t* data;
     uint8_t* cursor;
     uint64_t data_size;
@@ -163,6 +166,10 @@ struct OasisState {
     Array<PropertyValue*> property_value_array;
     uint16_t config_flags;
 };
+
+size_t oasis_fread(void* buffer, size_t size, size_t count, OasisStream& in);
+
+int64_t oasis_fseek(OasisStream& in, int64_t pos, int whence);
 
 ErrorCode oasis_read(void* buffer, size_t size, size_t count, OasisStream& in);
 

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -421,9 +421,10 @@ ErrorCode Polygon::to_gds(FILE* out, double scaling) const {
 
     uint64_t total = point_array.count + 1;
     if (total > 8190) {
-        fputs(
-            "[GDSTK] Polygons with more than 8190 are not supported by the official GDSII specification. This GDSII file might not be compatible with all readers.\n",
-            stderr);
+        if (error_logger)
+            fputs(
+                "[GDSTK] Polygons with more than 8190 are not supported by the official GDSII specification. This GDSII file might not be compatible with all readers.\n",
+                error_logger);
         error_code = ErrorCode::UnofficialSpecification;
     }
     Array<int32_t> coords = {};
@@ -1598,7 +1599,8 @@ ErrorCode contour(const double* data, uint64_t rows, uint64_t cols, double level
             }
         }
         if (!found) {
-            fprintf(stderr, "[GDSTK] Unable to process polygon hole in contour.\n");
+            if (error_logger)
+                fprintf(error_logger, "[GDSTK] Unable to process polygon hole in contour.\n");
             error_code = ErrorCode::BooleanError;
             hole->clear();
             free_allocation(hole);

--- a/src/property.cpp
+++ b/src/property.cpp
@@ -332,9 +332,10 @@ ErrorCode properties_to_gds(const Property* properties, FILE* out) {
         if (free_bytes) free_allocation(bytes);
     }
     if (count > 128) {
-        fputs(
-            "[GDSTK] Properties with count larger than 128 bytes are not officially supported by the GDSII specification.  This file might not be compatible with all readers.\n",
-            stderr);
+        if (error_logger)
+            fputs(
+                "[GDSTK] Properties with count larger than 128 bytes are not officially supported by the GDSII specification.  This file might not be compatible with all readers.\n",
+                error_logger);
         return ErrorCode::UnofficialSpecification;
     }
     return ErrorCode::NoError;

--- a/src/reference.cpp
+++ b/src/reference.cpp
@@ -426,9 +426,10 @@ ErrorCode Reference::to_gds(FILE* out, double scaling) const {
 
         if (array) {
             if (repetition.columns > UINT16_MAX || repetition.rows > UINT16_MAX) {
-                fputs(
-                    "[GDSTK] Repetition with more than 65535 columns or rows cannot be saved to a GDSII file.\n",
-                    stderr);
+                if (error_logger)
+                    fputs(
+                        "[GDSTK] Repetition with more than 65535 columns or rows cannot be saved to a GDSII file.\n",
+                        error_logger);
                 error_code = ErrorCode::InvalidRepetition;
                 buffer_array[2] = UINT16_MAX;
                 buffer_array[3] = UINT16_MAX;

--- a/src/robustpath.cpp
+++ b/src/robustpath.cpp
@@ -1069,10 +1069,11 @@ ErrorCode RobustPath::spine_intersection(const SubPath &sub0, const SubPath &sub
             du1 /= norm_v1;
         }
     }
-    fprintf(
-        stderr,
-        "[GDSTK] No intersection found in RobustPath spine construction around (%lg, %lg) and (%lg, %lg).\n",
-        p0.x, p0.y, p1.x, p1.y);
+    if (error_logger)
+        fprintf(
+            error_logger,
+            "[GDSTK] No intersection found in RobustPath spine construction around (%lg, %lg) and (%lg, %lg).\n",
+            p0.x, p0.y, p1.x, p1.y);
     return ErrorCode::IntersectionNotFound;
 }
 
@@ -1123,10 +1124,11 @@ ErrorCode RobustPath::center_intersection(const SubPath &sub0, const Interpolati
             du1 /= norm_v1;
         }
     }
-    fprintf(
-        stderr,
-        "[GDSTK] No intersection found in RobustPath center construction around (%lg, %lg) and (%lg, %lg).\n",
-        p0.x, p0.y, p1.x, p1.y);
+    if (error_logger)
+        fprintf(
+            error_logger,
+            "[GDSTK] No intersection found in RobustPath center construction around (%lg, %lg) and (%lg, %lg).\n",
+            p0.x, p0.y, p1.x, p1.y);
     return ErrorCode::IntersectionNotFound;
 }
 
@@ -1178,10 +1180,11 @@ ErrorCode RobustPath::left_intersection(const SubPath &sub0, const Interpolation
             du1 /= norm_v1;
         }
     }
-    fprintf(
-        stderr,
-        "[GDSTK] No intersection found in RobustPath left side construction around (%lg, %lg) and (%lg, %lg).\n",
-        p0.x, p0.y, p1.x, p1.y);
+    if (error_logger)
+        fprintf(
+            error_logger,
+            "[GDSTK] No intersection found in RobustPath left side construction around (%lg, %lg) and (%lg, %lg).\n",
+            p0.x, p0.y, p1.x, p1.y);
     return ErrorCode::IntersectionNotFound;
 }
 
@@ -1233,10 +1236,11 @@ ErrorCode RobustPath::right_intersection(const SubPath &sub0, const Interpolatio
             du1 /= norm_v1;
         }
     }
-    fprintf(
-        stderr,
-        "[GDSTK] No intersection found in RobustPath right side construction around (%lg, %lg) and (%lg, %lg).\n",
-        p0.x, p0.y, p1.x, p1.y);
+    if (error_logger)
+        fprintf(
+            error_logger,
+            "[GDSTK] No intersection found in RobustPath right side construction around (%lg, %lg) and (%lg, %lg).\n",
+            p0.x, p0.y, p1.x, p1.y);
     return ErrorCode::IntersectionNotFound;
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -23,6 +23,11 @@ LICENSE file or <http://www.boost.org/LICENSE_1_0.txt>
 
 namespace gdstk {
 
+#define UTILS_UNIT
+FILE* error_logger = stderr;
+
+void set_error_logger(FILE* log) { error_logger = log; }
+
 char* copy_string(const char* str, uint64_t* len) {
     uint64_t size = 1 + strlen(str);
     char* result = (char*)allocate(size);
@@ -572,10 +577,10 @@ void convex_hull(const Array<Vec2> points, Array<Vec2>& result) {
 
     qhT qh;
     QHULL_LIB_CHECK;
-    qh_zero(&qh, stderr);
+    qh_zero(&qh, error_logger);
     char command[256] = "qhull";
     int exitcode = qh_new_qhull(&qh, 2, (int)points.count, (double*)points.items, false, command,
-                                NULL, stderr);
+                                NULL, error_logger);
 
     if (exitcode == 0) {
         result.ensure_slots(qh.num_facets);
@@ -617,7 +622,7 @@ void convex_hull(const Array<Vec2> points, Array<Vec2>& result) {
     qh_memfreeshort(&qh, &curlong, &totlong); /* free short memory and memory allocator */
     if (curlong || totlong) {
         fprintf(
-            stderr,
+            error_logger,
             "[GDSTK] Qhull internal warning: did not free %d bytes of long memory (%d pieces)\n",
             totlong, curlong);
     }

--- a/src/utils.h
+++ b/src/utils.h
@@ -34,15 +34,15 @@ LICENSE file or <http://www.boost.org/LICENSE_1_0.txt>
 #define DEBUG_HERE ((void)0)
 #define DEBUG_PRINT(...) ((void)0)
 #else
-#define DEBUG_HERE                                                   \
-    do {                                                             \
-        fprintf(stderr, "%s:%d:%s\n", __FILE__, __LINE__, __func__); \
-        fflush(stderr);                                              \
+#define DEBUG_HERE                                                         \
+    do {                                                                   \
+        fprintf(error_logger, "%s:%d:%s\n", __FILE__, __LINE__, __func__); \
+        fflush(error_logger);                                              \
     } while (false)
-#define DEBUG_PRINT(...)              \
-    do {                              \
-        fprintf(stderr, __VA_ARGS__); \
-        fflush(stderr);               \
+#define DEBUG_PRINT(...)                    \
+    do {                                    \
+        fprintf(error_logger, __VA_ARGS__); \
+        fflush(error_logger);               \
     } while (false)
 #endif
 
@@ -227,6 +227,9 @@ inline uint64_t hash(const char* key) {
     }
     return result;
 }
+
+extern FILE* error_logger;
+void set_error_logger(FILE* log);
 
 }  // namespace gdstk
 

--- a/src/zfstream/zfstream.cc
+++ b/src/zfstream/zfstream.cc
@@ -1,0 +1,376 @@
+/*
+ * A C++ I/O streams interface to the zlib gz* functions
+ *
+ * by Ludwig Schwardt <schwardt@sun.ac.za>
+ * original version by Kevin Ruland <kevin@rodin.wustl.edu>
+ *
+ * This version is standard-compliant and compatible with gcc 3.x.
+ */
+
+#include "zfstream.h"
+
+#include <cstdio>   // for BUFSIZ
+#include <cstring>  // for strcpy, strcat, strlen (mode strings)
+
+// Internal buffer sizes (default and "unbuffered" versions)
+#define BIGBUFSIZE BUFSIZ
+#define SMALLBUFSIZE 1
+
+/*****************************************************************************/
+
+// Default constructor
+gzfilebuf::gzfilebuf()
+    : file(NULL),
+      io_mode(std::ios_base::openmode(0)),
+      own_fd(false),
+      buffer(NULL),
+      buffer_size(BIGBUFSIZE),
+      own_buffer(true) {
+    // No buffers to start with
+    this->disable_buffer();
+}
+
+// Destructor
+gzfilebuf::~gzfilebuf() {
+    // Sync output buffer and close only if responsible for file
+    // (i.e. attached streams should be left open at this stage)
+    this->sync();
+    if (own_fd) this->close();
+    // Make sure internal buffer is deallocated
+    this->disable_buffer();
+}
+
+// Set compression level and strategy
+int gzfilebuf::setcompression(int comp_level, int comp_strategy) {
+    return gzsetparams(file, comp_level, comp_strategy);
+}
+
+// Open gzipped file
+gzfilebuf* gzfilebuf::open(const char* name, std::ios_base::openmode mode) {
+    // Fail if file already open
+    if (this->is_open()) return NULL;
+    // Don't support simultaneous read/write access (yet)
+    if ((mode & std::ios_base::in) && (mode & std::ios_base::out)) return NULL;
+
+    // Build mode string for gzopen and check it [27.8.1.3.2]
+    char char_mode[6] = "\0\0\0\0\0";
+    if (!this->open_mode(mode, char_mode)) return NULL;
+
+    // Attempt to open file
+    if ((file = gzopen(name, char_mode)) == NULL) return NULL;
+
+    // On success, allocate internal buffer and set flags
+    this->enable_buffer();
+    io_mode = mode;
+    own_fd = true;
+    return this;
+}
+
+// Attach to gzipped file
+gzfilebuf* gzfilebuf::attach(int fd, std::ios_base::openmode mode) {
+    // Fail if file already open
+    if (this->is_open()) return NULL;
+    // Don't support simultaneous read/write access (yet)
+    if ((mode & std::ios_base::in) && (mode & std::ios_base::out)) return NULL;
+
+    // Build mode string for gzdopen and check it [27.8.1.3.2]
+    char char_mode[6] = "\0\0\0\0\0";
+    if (!this->open_mode(mode, char_mode)) return NULL;
+
+    // Attempt to attach to file
+    if ((file = gzdopen(fd, char_mode)) == NULL) return NULL;
+
+    // On success, allocate internal buffer and set flags
+    this->enable_buffer();
+    io_mode = mode;
+    own_fd = false;
+    return this;
+}
+
+// Close gzipped file
+gzfilebuf* gzfilebuf::close() {
+    // Fail immediately if no file is open
+    if (!this->is_open()) return NULL;
+    // Assume success
+    gzfilebuf* retval = this;
+    // Attempt to sync and close gzipped file
+    if (this->sync() == -1) retval = NULL;
+    if (gzclose(file) < 0) retval = NULL;
+    // File is now gone anyway (postcondition [27.8.1.3.8])
+    file = NULL;
+    own_fd = false;
+    // Destroy internal buffer if it exists
+    this->disable_buffer();
+    return retval;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+// Convert int open mode to mode string
+bool gzfilebuf::open_mode(std::ios_base::openmode mode, char* c_mode) const {
+    bool testb = mode & std::ios_base::binary;
+    bool testi = mode & std::ios_base::in;
+    bool testo = mode & std::ios_base::out;
+    bool testt = mode & std::ios_base::trunc;
+    bool testa = mode & std::ios_base::app;
+
+    // Check for valid flag combinations - see [27.8.1.3.2] (Table 92)
+    // Original zfstream hardcoded the compression level to maximum here...
+    // Double the time for less than 1% size improvement seems
+    // excessive though - keeping it at the default level
+    // To change back, just append "9" to the next three mode strings
+    if (!testi && testo && !testt && !testa) strcpy(c_mode, "w");
+    if (!testi && testo && !testt && testa) strcpy(c_mode, "a");
+    if (!testi && testo && testt && !testa) strcpy(c_mode, "w");
+    if (testi && !testo && !testt && !testa) strcpy(c_mode, "r");
+    // No read/write mode yet
+    //  if (testi && testo && !testt && !testa)
+    //    strcpy(c_mode, "r+");
+    //  if (testi && testo && testt && !testa)
+    //    strcpy(c_mode, "w+");
+
+    // Mode string should be empty for invalid combination of flags
+    if (strlen(c_mode) == 0) return false;
+    if (testb) strcat(c_mode, "b");
+    return true;
+}
+
+// Determine number of characters in internal get buffer
+std::streamsize gzfilebuf::showmanyc() {
+    // Calls to underflow will fail if file not opened for reading
+    if (!this->is_open() || !(io_mode & std::ios_base::in)) return -1;
+    // Make sure get area is in use
+    if (this->gptr() && (this->gptr() < this->egptr()))
+        return std::streamsize(this->egptr() - this->gptr());
+    else
+        return 0;
+}
+
+// Fill get area from gzipped file
+gzfilebuf::int_type gzfilebuf::underflow() {
+    // If something is left in the get area by chance, return it
+    // (this shouldn't normally happen, as underflow is only supposed
+    // to be called when gptr >= egptr, but it serves as error check)
+    if (this->gptr() && (this->gptr() < this->egptr()))
+        return traits_type::to_int_type(*(this->gptr()));
+
+    // If the file hasn't been opened for reading, produce error
+    if (!this->is_open() || !(io_mode & std::ios_base::in)) return traits_type::eof();
+
+    // Attempt to fill internal buffer from gzipped file
+    // (buffer must be guaranteed to exist...)
+    int bytes_read = gzread(file, buffer, buffer_size);
+    // Indicates error or EOF
+    if (bytes_read <= 0) {
+        // Reset get area
+        this->setg(buffer, buffer, buffer);
+        return traits_type::eof();
+    }
+    // Make all bytes read from file available as get area
+    this->setg(buffer, buffer, buffer + bytes_read);
+
+    // Return next character in get area
+    return traits_type::to_int_type(*(this->gptr()));
+}
+
+// Write put area to gzipped file
+gzfilebuf::int_type gzfilebuf::overflow(int_type c) {
+    // Determine whether put area is in use
+    if (this->pbase()) {
+        // Double-check pointer range
+        if (this->pptr() > this->epptr() || this->pptr() < this->pbase()) return traits_type::eof();
+        // Add extra character to buffer if not EOF
+        if (!traits_type::eq_int_type(c, traits_type::eof())) {
+            *(this->pptr()) = traits_type::to_char_type(c);
+            this->pbump(1);
+        }
+        // Number of characters to write to file
+        int bytes_to_write = this->pptr() - this->pbase();
+        // Overflow doesn't fail if nothing is to be written
+        if (bytes_to_write > 0) {
+            // If the file hasn't been opened for writing, produce error
+            if (!this->is_open() || !(io_mode & std::ios_base::out)) return traits_type::eof();
+            // If gzipped file won't accept all bytes written to it, fail
+            if (gzwrite(file, this->pbase(), bytes_to_write) != bytes_to_write)
+                return traits_type::eof();
+            // Reset next pointer to point to pbase on success
+            this->pbump(-bytes_to_write);
+        }
+    }
+    // Write extra character to file if not EOF
+    else if (!traits_type::eq_int_type(c, traits_type::eof())) {
+        // If the file hasn't been opened for writing, produce error
+        if (!this->is_open() || !(io_mode & std::ios_base::out)) return traits_type::eof();
+        // Impromptu char buffer (allows "unbuffered" output)
+        char_type last_char = traits_type::to_char_type(c);
+        // If gzipped file won't accept this character, fail
+        if (gzwrite(file, &last_char, 1) != 1) return traits_type::eof();
+    }
+
+    // If you got here, you have succeeded (even if c was EOF)
+    // The return value should therefore be non-EOF
+    if (traits_type::eq_int_type(c, traits_type::eof()))
+        return traits_type::not_eof(c);
+    else
+        return c;
+}
+
+// Assign new buffer
+std::streambuf* gzfilebuf::setbuf(char_type* p, std::streamsize n) {
+    // First make sure stuff is sync'ed, for safety
+    if (this->sync() == -1) return NULL;
+    // If buffering is turned off on purpose via setbuf(0,0), still allocate one...
+    // "Unbuffered" only really refers to put [27.8.1.4.10], while get needs at
+    // least a buffer of size 1 (very inefficient though, therefore make it bigger?)
+    // This follows from [27.5.2.4.3]/12 (gptr needs to point at something, it seems)
+    if (!p || !n) {
+        // Replace existing buffer (if any) with small internal buffer
+        this->disable_buffer();
+        buffer = NULL;
+        buffer_size = 0;
+        own_buffer = true;
+        this->enable_buffer();
+    } else {
+        // Replace existing buffer (if any) with external buffer
+        this->disable_buffer();
+        buffer = p;
+        buffer_size = n;
+        own_buffer = false;
+        this->enable_buffer();
+    }
+    return this;
+}
+
+// Write put area to gzipped file (i.e. ensures that put area is empty)
+int gzfilebuf::sync() {
+    return traits_type::eq_int_type(this->overflow(), traits_type::eof()) ? -1 : 0;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+// Allocate internal buffer
+void gzfilebuf::enable_buffer() {
+    // If internal buffer required, allocate one
+    if (own_buffer && !buffer) {
+        // Check for buffered vs. "unbuffered"
+        if (buffer_size > 0) {
+            // Allocate internal buffer
+            buffer = new char_type[buffer_size];
+            // Get area starts empty and will be expanded by underflow as need arises
+            this->setg(buffer, buffer, buffer);
+            // Setup entire internal buffer as put area.
+            // The one-past-end pointer actually points to the last element of the buffer,
+            // so that overflow(c) can safely add the extra character c to the sequence.
+            // These pointers remain in place for the duration of the buffer
+            this->setp(buffer, buffer + buffer_size - 1);
+        } else {
+            // Even in "unbuffered" case, (small?) get buffer is still required
+            buffer_size = SMALLBUFSIZE;
+            buffer = new char_type[buffer_size];
+            this->setg(buffer, buffer, buffer);
+            // "Unbuffered" means no put buffer
+            this->setp(0, 0);
+        }
+    } else {
+        // If buffer already allocated, reset buffer pointers just to make sure no
+        // stale chars are lying around
+        this->setg(buffer, buffer, buffer);
+        this->setp(buffer, buffer + buffer_size - 1);
+    }
+}
+
+// Destroy internal buffer
+void gzfilebuf::disable_buffer() {
+    // If internal buffer exists, deallocate it
+    if (own_buffer && buffer) {
+        // Preserve unbuffered status by zeroing size
+        if (!this->pbase()) buffer_size = 0;
+        delete[] buffer;
+        buffer = NULL;
+        this->setg(0, 0, 0);
+        this->setp(0, 0);
+    } else {
+        // Reset buffer pointers to initial state if external buffer exists
+        this->setg(buffer, buffer, buffer);
+        if (buffer)
+            this->setp(buffer, buffer + buffer_size - 1);
+        else
+            this->setp(0, 0);
+    }
+}
+
+/*****************************************************************************/
+
+// Default constructor initializes stream buffer
+gzifstream::gzifstream() : std::istream(NULL), sb() { this->init(&sb); }
+
+// Initialize stream buffer and open file
+gzifstream::gzifstream(const char* name, std::ios_base::openmode mode) : std::istream(NULL), sb() {
+    this->init(&sb);
+    this->open(name, mode);
+}
+
+// Initialize stream buffer and attach to file
+gzifstream::gzifstream(int fd, std::ios_base::openmode mode) : std::istream(NULL), sb() {
+    this->init(&sb);
+    this->attach(fd, mode);
+}
+
+// Open file and go into fail() state if unsuccessful
+void gzifstream::open(const char* name, std::ios_base::openmode mode) {
+    if (!sb.open(name, mode | std::ios_base::in))
+        this->setstate(std::ios_base::failbit);
+    else
+        this->clear();
+}
+
+// Attach to file and go into fail() state if unsuccessful
+void gzifstream::attach(int fd, std::ios_base::openmode mode) {
+    if (!sb.attach(fd, mode | std::ios_base::in))
+        this->setstate(std::ios_base::failbit);
+    else
+        this->clear();
+}
+
+// Close file
+void gzifstream::close() {
+    if (!sb.close()) this->setstate(std::ios_base::failbit);
+}
+
+/*****************************************************************************/
+
+// Default constructor initializes stream buffer
+gzofstream::gzofstream() : std::ostream(NULL), sb() { this->init(&sb); }
+
+// Initialize stream buffer and open file
+gzofstream::gzofstream(const char* name, std::ios_base::openmode mode) : std::ostream(NULL), sb() {
+    this->init(&sb);
+    this->open(name, mode);
+}
+
+// Initialize stream buffer and attach to file
+gzofstream::gzofstream(int fd, std::ios_base::openmode mode) : std::ostream(NULL), sb() {
+    this->init(&sb);
+    this->attach(fd, mode);
+}
+
+// Open file and go into fail() state if unsuccessful
+void gzofstream::open(const char* name, std::ios_base::openmode mode) {
+    if (!sb.open(name, mode | std::ios_base::out))
+        this->setstate(std::ios_base::failbit);
+    else
+        this->clear();
+}
+
+// Attach to file and go into fail() state if unsuccessful
+void gzofstream::attach(int fd, std::ios_base::openmode mode) {
+    if (!sb.attach(fd, mode | std::ios_base::out))
+        this->setstate(std::ios_base::failbit);
+    else
+        this->clear();
+}
+
+// Close file
+void gzofstream::close() {
+    if (!sb.close()) this->setstate(std::ios_base::failbit);
+}

--- a/src/zfstream/zfstream.h
+++ b/src/zfstream/zfstream.h
@@ -1,0 +1,410 @@
+/*
+ * A C++ I/O streams interface to the zlib gz* functions
+ *
+ * by Ludwig Schwardt <schwardt@sun.ac.za>
+ * original version by Kevin Ruland <kevin@rodin.wustl.edu>
+ *
+ * This version is standard-compliant and compatible with gcc 3.x.
+ */
+
+#ifndef ZFSTREAM_H
+#define ZFSTREAM_H
+
+#include <istream>  // not iostream, since we don't need cin/cout
+#include <ostream>
+
+#include "zlib.h"
+
+/*****************************************************************************/
+
+/**
+ *  @brief  Gzipped file stream buffer class.
+ *
+ *  This class implements basic_filebuf for gzipped files. It doesn't yet support
+ *  seeking (allowed by zlib but slow/limited), putback and read/write access
+ *  (tricky). Otherwise, it attempts to be a drop-in replacement for the standard
+ *  file streambuf.
+ */
+class gzfilebuf : public std::streambuf {
+   public:
+    //  Default constructor.
+    gzfilebuf();
+
+    //  Destructor.
+    virtual ~gzfilebuf();
+
+    /**
+     *  @brief  Set compression level and strategy on the fly.
+     *  @param  comp_level  Compression level (see zlib.h for allowed values)
+     *  @param  comp_strategy  Compression strategy (see zlib.h for allowed values)
+     *  @return  Z_OK on success, Z_STREAM_ERROR otherwise.
+     *
+     *  Unfortunately, these parameters cannot be modified separately, as the
+     *  previous zfstream version assumed. Since the strategy is seldom changed,
+     *  it can default and setcompression(level) then becomes like the old
+     *  setcompressionlevel(level).
+     */
+    int setcompression(int comp_level, int comp_strategy = Z_DEFAULT_STRATEGY);
+
+    /**
+     *  @brief  Check if file is open.
+     *  @return  True if file is open.
+     */
+    bool is_open() const { return (file != NULL); }
+
+    /**
+     *  @brief  Open gzipped file.
+     *  @param  name  File name.
+     *  @param  mode  Open mode flags.
+     *  @return  @c this on success, NULL on failure.
+     */
+    gzfilebuf* open(const char* name, std::ios_base::openmode mode);
+
+    /**
+     *  @brief  Attach to already open gzipped file.
+     *  @param  fd  File descriptor.
+     *  @param  mode  Open mode flags.
+     *  @return  @c this on success, NULL on failure.
+     */
+    gzfilebuf* attach(int fd, std::ios_base::openmode mode);
+
+    /**
+     *  @brief  Close gzipped file.
+     *  @return  @c this on success, NULL on failure.
+     */
+    gzfilebuf* close();
+
+   protected:
+    /**
+     *  @brief  Convert ios open mode int to mode string used by zlib.
+     *  @return  True if valid mode flag combination.
+     */
+    bool open_mode(std::ios_base::openmode mode, char* c_mode) const;
+
+    /**
+     *  @brief  Number of characters available in stream buffer.
+     *  @return  Number of characters.
+     *
+     *  This indicates number of characters in get area of stream buffer.
+     *  These characters can be read without accessing the gzipped file.
+     */
+    virtual std::streamsize showmanyc();
+
+    /**
+     *  @brief  Fill get area from gzipped file.
+     *  @return  First character in get area on success, EOF on error.
+     *
+     *  This actually reads characters from gzipped file to stream
+     *  buffer. Always buffered.
+     */
+    virtual int_type underflow();
+
+    /**
+     *  @brief  Write put area to gzipped file.
+     *  @param  c  Extra character to add to buffer contents.
+     *  @return  Non-EOF on success, EOF on error.
+     *
+     *  This actually writes characters in stream buffer to
+     *  gzipped file. With unbuffered output this is done one
+     *  character at a time.
+     */
+    virtual int_type overflow(int_type c = traits_type::eof());
+
+    /**
+     *  @brief  Installs external stream buffer.
+     *  @param  p  Pointer to char buffer.
+     *  @param  n  Size of external buffer.
+     *  @return  @c this on success, NULL on failure.
+     *
+     *  Call setbuf(0,0) to enable unbuffered output.
+     */
+    virtual std::streambuf* setbuf(char_type* p, std::streamsize n);
+
+    /**
+     *  @brief  Flush stream buffer to file.
+     *  @return  0 on success, -1 on error.
+     *
+     *  This calls underflow(EOF) to do the job.
+     */
+    virtual int sync();
+
+    //
+    // Some future enhancements
+    //
+    //  virtual int_type uflow();
+    //  virtual int_type pbackfail(int_type c = traits_type::eof());
+    //  virtual pos_type
+    //  seekoff(off_type off,
+    //          std::ios_base::seekdir way,
+    //          std::ios_base::openmode mode = std::ios_base::in|std::ios_base::out);
+    //  virtual pos_type
+    //  seekpos(pos_type sp,
+    //          std::ios_base::openmode mode = std::ios_base::in|std::ios_base::out);
+
+   private:
+    /**
+     *  @brief  Allocate internal buffer.
+     *
+     *  This function is safe to call multiple times. It will ensure
+     *  that a proper internal buffer exists if it is required. If the
+     *  buffer already exists or is external, the buffer pointers will be
+     *  reset to their original state.
+     */
+    void enable_buffer();
+
+    /**
+     *  @brief  Destroy internal buffer.
+     *
+     *  This function is safe to call multiple times. It will ensure
+     *  that the internal buffer is deallocated if it exists. In any
+     *  case, it will also reset the buffer pointers.
+     */
+    void disable_buffer();
+
+    /**
+     *  Underlying file pointer.
+     */
+    gzFile file;
+
+    /**
+     *  Mode in which file was opened.
+     */
+    std::ios_base::openmode io_mode;
+
+    /**
+     *  @brief  True if this object owns file descriptor.
+     *
+     *  This makes the class responsible for closing the file
+     *  upon destruction.
+     */
+    bool own_fd;
+
+    /**
+     *  @brief  Stream buffer.
+     *
+     *  For simplicity this remains allocated on the free store for the
+     *  entire life span of the gzfilebuf object, unless replaced by setbuf.
+     */
+    char_type* buffer;
+
+    /**
+     *  @brief  Stream buffer size.
+     *
+     *  Defaults to system default buffer size (typically 8192 bytes).
+     *  Modified by setbuf.
+     */
+    std::streamsize buffer_size;
+
+    /**
+     *  @brief  True if this object owns stream buffer.
+     *
+     *  This makes the class responsible for deleting the buffer
+     *  upon destruction.
+     */
+    bool own_buffer;
+};
+
+/*****************************************************************************/
+
+/**
+ *  @brief  Gzipped file input stream class.
+ *
+ *  This class implements ifstream for gzipped files. Seeking and putback
+ *  is not supported yet.
+ */
+class gzifstream : public std::istream {
+   public:
+    //  Default constructor
+    gzifstream();
+
+    /**
+     *  @brief  Construct stream on gzipped file to be opened.
+     *  @param  name  File name.
+     *  @param  mode  Open mode flags (forced to contain ios::in).
+     */
+    explicit gzifstream(const char* name, std::ios_base::openmode mode = std::ios_base::in);
+
+    /**
+     *  @brief  Construct stream on already open gzipped file.
+     *  @param  fd    File descriptor.
+     *  @param  mode  Open mode flags (forced to contain ios::in).
+     */
+    explicit gzifstream(int fd, std::ios_base::openmode mode = std::ios_base::in);
+
+    /**
+     *  Obtain underlying stream buffer.
+     */
+    gzfilebuf* rdbuf() const { return const_cast<gzfilebuf*>(&sb); }
+
+    /**
+     *  @brief  Check if file is open.
+     *  @return  True if file is open.
+     */
+    bool is_open() { return sb.is_open(); }
+
+    /**
+     *  @brief  Open gzipped file.
+     *  @param  name  File name.
+     *  @param  mode  Open mode flags (forced to contain ios::in).
+     *
+     *  Stream will be in state good() if file opens successfully;
+     *  otherwise in state fail(). This differs from the behavior of
+     *  ifstream, which never sets the state to good() and therefore
+     *  won't allow you to reuse the stream for a second file unless
+     *  you manually clear() the state. The choice is a matter of
+     *  convenience.
+     */
+    void open(const char* name, std::ios_base::openmode mode = std::ios_base::in);
+
+    /**
+     *  @brief  Attach to already open gzipped file.
+     *  @param  fd  File descriptor.
+     *  @param  mode  Open mode flags (forced to contain ios::in).
+     *
+     *  Stream will be in state good() if attach succeeded; otherwise
+     *  in state fail().
+     */
+    void attach(int fd, std::ios_base::openmode mode = std::ios_base::in);
+
+    /**
+     *  @brief  Close gzipped file.
+     *
+     *  Stream will be in state fail() if close failed.
+     */
+    void close();
+
+   private:
+    /**
+     *  Underlying stream buffer.
+     */
+    gzfilebuf sb;
+};
+
+/*****************************************************************************/
+
+/**
+ *  @brief  Gzipped file output stream class.
+ *
+ *  This class implements ofstream for gzipped files. Seeking and putback
+ *  is not supported yet.
+ */
+class gzofstream : public std::ostream {
+   public:
+    //  Default constructor
+    gzofstream();
+
+    /**
+     *  @brief  Construct stream on gzipped file to be opened.
+     *  @param  name  File name.
+     *  @param  mode  Open mode flags (forced to contain ios::out).
+     */
+    explicit gzofstream(const char* name, std::ios_base::openmode mode = std::ios_base::out);
+
+    /**
+     *  @brief  Construct stream on already open gzipped file.
+     *  @param  fd    File descriptor.
+     *  @param  mode  Open mode flags (forced to contain ios::out).
+     */
+    explicit gzofstream(int fd, std::ios_base::openmode mode = std::ios_base::out);
+
+    /**
+     *  Obtain underlying stream buffer.
+     */
+    gzfilebuf* rdbuf() const { return const_cast<gzfilebuf*>(&sb); }
+
+    /**
+     *  @brief  Check if file is open.
+     *  @return  True if file is open.
+     */
+    bool is_open() { return sb.is_open(); }
+
+    /**
+     *  @brief  Open gzipped file.
+     *  @param  name  File name.
+     *  @param  mode  Open mode flags (forced to contain ios::out).
+     *
+     *  Stream will be in state good() if file opens successfully;
+     *  otherwise in state fail(). This differs from the behavior of
+     *  ofstream, which never sets the state to good() and therefore
+     *  won't allow you to reuse the stream for a second file unless
+     *  you manually clear() the state. The choice is a matter of
+     *  convenience.
+     */
+    void open(const char* name, std::ios_base::openmode mode = std::ios_base::out);
+
+    /**
+     *  @brief  Attach to already open gzipped file.
+     *  @param  fd  File descriptor.
+     *  @param  mode  Open mode flags (forced to contain ios::out).
+     *
+     *  Stream will be in state good() if attach succeeded; otherwise
+     *  in state fail().
+     */
+    void attach(int fd, std::ios_base::openmode mode = std::ios_base::out);
+
+    /**
+     *  @brief  Close gzipped file.
+     *
+     *  Stream will be in state fail() if close failed.
+     */
+    void close();
+
+   private:
+    /**
+     *  Underlying stream buffer.
+     */
+    gzfilebuf sb;
+};
+
+/*****************************************************************************/
+
+/**
+ *  @brief  Gzipped file output stream manipulator class.
+ *
+ *  This class defines a two-argument manipulator for gzofstream. It is used
+ *  as base for the setcompression(int,int) manipulator.
+ */
+template <typename T1, typename T2>
+class gzomanip2 {
+   public:
+    // Allows insertor to peek at internals
+    template <typename Ta, typename Tb>
+    friend gzofstream& operator<<(gzofstream&, const gzomanip2<Ta, Tb>&);
+
+    // Constructor
+    gzomanip2(gzofstream& (*f)(gzofstream&, T1, T2), T1 v1, T2 v2);
+
+   private:
+    // Underlying manipulator function
+    gzofstream& (*func)(gzofstream&, T1, T2);
+
+    // Arguments for manipulator function
+    T1 val1;
+    T2 val2;
+};
+
+/*****************************************************************************/
+
+// Manipulator function thunks through to stream buffer
+inline gzofstream& setcompression(gzofstream& gzs, int l, int s = Z_DEFAULT_STRATEGY) {
+    (gzs.rdbuf())->setcompression(l, s);
+    return gzs;
+}
+
+// Manipulator constructor stores arguments
+template <typename T1, typename T2>
+inline gzomanip2<T1, T2>::gzomanip2(gzofstream& (*f)(gzofstream&, T1, T2), T1 v1, T2 v2)
+    : func(f), val1(v1), val2(v2) {}
+
+// Insertor applies underlying manipulator function to stream
+template <typename T1, typename T2>
+inline gzofstream& operator<<(gzofstream& s, const gzomanip2<T1, T2>& m) {
+    return (*m.func)(s, m.val1, m.val2);
+}
+
+// Insert this onto stream to simplify setting of compression level
+inline gzomanip2<int, int> setcompression(int l, int s = Z_DEFAULT_STRATEGY) {
+    return gzomanip2<int, int>(&setcompression, l, s);
+}
+
+#endif  // ZFSTREAM_H


### PR DESCRIPTION
Unlike oasis files gds files do not inherently support compression and these are often externally compressed, usually as gds.gz. This pull request allows reading compressed gds files. 

In addition, it allows reading gds/oasis from istream objects, which may be useful e.g. for reading over network.