### PR TITLE
Re-enable manylinux builds

### DIFF
--- a/.github/workflows/pypi-packages.yml
+++ b/.github/workflows/pypi-packages.yml
@@ -21,6 +21,21 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
+  build_manylinux_wheels:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 12
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.12.3
+        env:
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
   build_wheels_windows:
     runs-on: windows-latest
     strategy:


### PR DESCRIPTION
Bring forward build_manylinux_wheels job from 0.9.37.