### PR TITLE
Fix test failure due to FMA instruction

### DIFF
--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -165,8 +165,8 @@ def test_rw_gds(tmpdir, sample_library):
     assert c.references[0].x_reflection == True
     assert c.references[0].repetition.columns == 2
     assert c.references[0].repetition.rows == 3
-    assert c.references[0].repetition.v1 == (-2.0, 0.0)
-    assert c.references[0].repetition.v2 == (0.0, 8.0)
+    assert c.references[0].repetition.v1 == pytest.approx((-2.0, 0.0))
+    assert c.references[0].repetition.v2 == pytest.approx((0.0, 8.0))
 
 
 def test_rw_gds_filter(tmpdir, sample_library):
@@ -220,8 +220,8 @@ def test_rw_gds_filter(tmpdir, sample_library):
     assert c.references[0].x_reflection == True
     assert c.references[0].repetition.columns == 2
     assert c.references[0].repetition.rows == 3
-    assert c.references[0].repetition.v1 == (-2.0, 0.0)
-    assert c.references[0].repetition.v2 == (0.0, 8.0)
+    assert c.references[0].repetition.v1 == pytest.approx((-2.0, 0.0))
+    assert c.references[0].repetition.v2 == pytest.approx((0.0, 8.0))
 
 
 def test_read_gds_missing_refs(tmpdir):


### PR DESCRIPTION
See https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1784.

The changed asserts are the ones that fails on riscv64:

```
>       assert c.references[0].repetition.v1 == (-2.0, 0.0)
E       assert (-2.0, -4.163336342344337e-17) == (-2.0, 0.0)
E         At index 1 diff: -4.163336342344337e-17 != 0.0
E         Use -v to get more diff

tests/library_test.py:153: AssertionError
```

Other floating-point assert-equals may need to use `pytest.approx` as well.