### PR TITLE
Fix missing version

### DIFF
--- a/gdstk/__init__.py
+++ b/gdstk/__init__.py
@@ -1,1 +1,2 @@
 from .gdstk import *
+from .gdstk import __version__


### PR DESCRIPTION
My previous patch forgot to import `__version__` (because I incorrectly assumed that wildcard imports import everything) which prevented the docs from building. This patch fixes that.

PS: Could you please make a release (0.9.43)?