### PR TITLE
Fix outdated pip in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,7 @@ jobs:
           cache: 'pip'
       - name: Install Python dependencies
         run: |
+          pip install --upgrade pip setuptools wheel
           pip install pip-tools
           python -m piptools compile --resolver=backtracking --extra=docs -o requirements.txt pyproject.toml
           pip install -r requirements.txt

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,6 +25,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
+          pip install --upgrade pip setuptools wheel
           pip install pip-tools pytest
           python -m piptools compile --resolver=backtracking -o requirements.txt pyproject.toml
           pip install -r requirements.txt


### PR DESCRIPTION
This should fix the CI for linux that broke because of a pip bug fixed in the most recent release (see https://github.com/jazzband/pip-tools/pull/1906).
