### PR TITLE
Correct ordering of path ends in `Library::read_oas()`

### DIFF
--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1926,31 +1926,31 @@ Library read_oas(const char* filename, double unit, double tolerance, ErrorCode*
                 if (info & 0x80) {
                     uint8_t extension_scheme;
                     oasis_read(&extension_scheme, 1, 1, in);
-                    switch (extension_scheme & 0x03) {
-                        case 0x01:
-                            modal_path_extensions.x = 0;
-                            break;
-                        case 0x02:
-                            modal_path_extensions.x = modal_path_halfwidth;
-                            break;
-                        case 0x03:
-                            modal_path_extensions.x = factor * oasis_read_integer(in);
-                    }
                     switch (extension_scheme & 0x0c) {
                         case 0x04:
-                            modal_path_extensions.y = 0;
+                            modal_path_extensions.u = 0;
                             break;
                         case 0x08:
-                            modal_path_extensions.y = modal_path_halfwidth;
+                            modal_path_extensions.u = modal_path_halfwidth;
                             break;
                         case 0x0c:
-                            modal_path_extensions.y = factor * oasis_read_integer(in);
+                            modal_path_extensions.u = factor * oasis_read_integer(in);
+                    }
+                    switch (extension_scheme & 0x03) {
+                        case 0x01:
+                            modal_path_extensions.v = 0;
+                            break;
+                        case 0x02:
+                            modal_path_extensions.v = modal_path_halfwidth;
+                            break;
+                        case 0x03:
+                            modal_path_extensions.v = factor * oasis_read_integer(in);
                     }
                 }
-                if (modal_path_extensions.x == 0 && modal_path_extensions.y == 0) {
+                if (modal_path_extensions.u == 0 && modal_path_extensions.v == 0) {
                     element->end_type = EndType::Flush;
-                } else if (modal_path_extensions.x == modal_path_halfwidth &&
-                           modal_path_extensions.y == modal_path_halfwidth) {
+                } else if (modal_path_extensions.u == modal_path_halfwidth &&
+                           modal_path_extensions.v == modal_path_halfwidth) {
                     element->end_type = EndType::HalfWidth;
                 } else {
                     element->end_type = EndType::Extended;


### PR DESCRIPTION
OASIS path extension options are stored in a single byte; the path start is located in bits 2 and 3, while the end is in bits 0 and 1. `FlexPath` and `RobustPath`'s `::write_oas()` method stores the extension data correctly, but `read_oas()` currently has the ordering reversed.

This PR updates the read order and adds a unit test.