### PR TITLE
Fix 2 crashes: Removing all occurrences reaching end of linked list, …

### DIFF
--- a/include/gdstk/array.hpp
+++ b/include/gdstk/array.hpp
@@ -29,7 +29,7 @@ template <class T>
 struct Array {
     uint64_t capacity;  // allocated capacity
     uint64_t count;     // number of slots used
-    T* items=NULL;           // slots
+    T* items=NULL;      // slots
 
     T& operator[](uint64_t idx) { return items[idx]; }
     const T& operator[](uint64_t idx) const { return items[idx]; }

--- a/include/gdstk/array.hpp
+++ b/include/gdstk/array.hpp
@@ -27,9 +27,9 @@ namespace gdstk {
 
 template <class T>
 struct Array {
-    uint64_t capacity;  // allocated capacity
-    uint64_t count;     // number of slots used
-    T* items=NULL;      // slots
+    uint64_t capacity = 0;  // allocated capacity
+    uint64_t count = 0;     // number of slots used
+    T* items = NULL;      // slots
 
     T& operator[](uint64_t idx) { return items[idx]; }
     const T& operator[](uint64_t idx) const { return items[idx]; }

--- a/include/gdstk/array.hpp
+++ b/include/gdstk/array.hpp
@@ -29,7 +29,7 @@ template <class T>
 struct Array {
     uint64_t capacity;  // allocated capacity
     uint64_t count;     // number of slots used
-    T* items;           // slots
+    T* items=NULL;           // slots
 
     T& operator[](uint64_t idx) { return items[idx]; }
     const T& operator[](uint64_t idx) const { return items[idx]; }

--- a/src/property.cpp
+++ b/src/property.cpp
@@ -239,7 +239,7 @@ void set_gds_property(Property*& properties, uint16_t attribute, const char* val
 uint64_t remove_property(Property*& properties, const char* name, bool all_occurences) {
     uint64_t removed = 0;
     if (properties == NULL) return removed;
-    while (strcmp(properties->name, name) == 0) {
+    while (properties != NULL && strcmp(properties->name, name) == 0) {
         property_values_clear(properties->value);
         free_allocation(properties->name);
         Property* next = properties->next;
@@ -248,6 +248,7 @@ uint64_t remove_property(Property*& properties, const char* name, bool all_occur
         removed++;
         if (!all_occurences) return removed;
     }
+    if (properties == NULL) return removed;
     Property* property = properties;
     while (true) {
         while (property->next && strcmp(property->next->name, name) != 0) property = property->next;


### PR DESCRIPTION
…and reallocating uninitialized array items pointer

When I tried to use this library it was crashing in these 2 places:
- When removing all instances of a property reaches the end of the linked list, NULL pointer was not checked for, resulting in crash
- When reallocating the items pointer in Array struct, the items pointer is not initialized so it can contain an invalid memory address and crash