### PR TITLE
Fix RaithData memory leaks

### DIFF
--- a/gdstk/_gdstk.pyi
+++ b/gdstk/_gdstk.pyi
@@ -15,7 +15,7 @@ else:
     from typing_extensions import Self
 
 import numpy
-from numpy.typing import ArrayLike # type: ignore
+from numpy.typing import ArrayLike  # type: ignore
 
 class Cell:
     labels: list[Label]
@@ -25,9 +25,13 @@ class Cell:
     properties: list[list[str | bytes | float]]
     references: list[Reference]
     def __init__(self, name: str) -> None: ...
-    def add(self, *elements: Polygon | FlexPath | RobustPath | Label | Reference) -> Self: ...
+    def add(
+        self, *elements: Polygon | FlexPath | RobustPath | Label | Reference
+    ) -> Self: ...
     def area(self, by_spec: bool = False) -> float | dict[tuple[int, int], float]: ...
-    def bounding_box(self) -> Optional[tuple[tuple[float, float], tuple[float, float]]]: ...
+    def bounding_box(
+        self,
+    ) -> Optional[tuple[tuple[float, float], tuple[float, float]]]: ...
     def convex_hull(self) -> numpy.ndarray[Any, numpy.dtype[numpy.float64]]: ...
     def copy(
         self,
@@ -72,7 +76,9 @@ class Cell:
         datatype: Optional[int] = None,
     ) -> list[Polygon]: ...
     def get_property(self, name: str) -> Optional[list[list[str | bytes | float]]]: ...
-    def remove(self, *elements: Label | Polygon | RobustPath | FlexPath | Reference) -> Self: ...
+    def remove(
+        self, *elements: Label | Polygon | RobustPath | FlexPath | Reference
+    ) -> Self: ...
     def set_property(
         self, name: str, value: str | bytes | float | Sequence[str | bytes | float]
     ) -> Self: ...
@@ -90,7 +96,9 @@ class Cell:
 
 class Curve:
     tolerance: float
-    def __init__(self, xy: tuple[float, float] | complex, tolerance: float = 0.01) -> None: ...
+    def __init__(
+        self, xy: tuple[float, float] | complex, tolerance: float = 0.01
+    ) -> None: ...
     def arc(
         self,
         radius: float | tuple[float, float],
@@ -108,7 +116,9 @@ class Curve:
     def cubic_smooth(
         self, xy: Sequence[tuple[float, float] | complex], relative: bool = False
     ) -> Self: ...
-    def horizontal(self, x: Sequence[float] | float, relative: bool = False) -> Self: ...
+    def horizontal(
+        self, x: Sequence[float] | float, relative: bool = False
+    ) -> Self: ...
     def interpolation(
         self,
         points: Sequence[tuple[float, float]],
@@ -141,14 +151,22 @@ class Curve:
     def vertical(self, y: float | Sequence[float], relative: bool = False) -> Self: ...
 
 class RaithData:
-    base_cell_name: str
-    dwelltime_selection: int
-    pitch_parallel_to_path: float
-    pitch_perpendicular_to_path: float
-    pitch_scale: float
-    periods: int
-    grating_type: int
-    dots_per_cycle: int
+    @property
+    def base_cell_name(self) -> str: ...
+    @property
+    def dwelltime_selection(self) -> int: ...
+    @property
+    def pitch_parallel_to_path(self) -> float: ...
+    @property
+    def pitch_perpendicular_to_path(self) -> float: ...
+    @property
+    def pitch_scale(self) -> float: ...
+    @property
+    def periods(self) -> int: ...
+    @property
+    def grating_type(self) -> int: ...
+    @property
+    def dots_per_cycle(self) -> int: ...
     def __init__(
         self,
         base_cell_name: str,
@@ -175,7 +193,9 @@ class FlexPath:
     ]
     joins: tuple[
         Literal["natural", "miter", "bevel", "round", "smooth"]
-        | Callable[[float, float, float, float, float, float], list[tuple[float, float]]],
+        | Callable[
+            [float, float, float, float, float, float], list[tuple[float, float]]
+        ],
         ...,
     ]
     layers: tuple[int, ...]
@@ -186,7 +206,7 @@ class FlexPath:
     simple_path: bool
     size: int
     tolerance: float
-    raith_data: RaithData
+    raith_data: Optional[RaithData]
     def __init__(
         self,
         points: tuple[float, float] | complex | Sequence[tuple[float, float] | complex],
@@ -194,28 +214,38 @@ class FlexPath:
         offset: float | Sequence[float] = 0,
         joins: Literal["natural", "miter", "bevel", "round", "smooth"]
         | Callable[
-            [float, float, float, float, float, float], Sequence[tuple[float, float] | complex]
+            [float, float, float, float, float, float],
+            Sequence[tuple[float, float] | complex],
         ]
         | Sequence[
             Literal["natural", "miter", "bevel", "round", "smooth"]
             | Callable[
-                [float, float, float, float, float, float], Sequence[tuple[float, float] | complex]
+                [float, float, float, float, float, float],
+                Sequence[tuple[float, float] | complex],
             ]
         ] = "natural",
         ends: Literal["flush", "extended", "round", "smooth"]
         | tuple[float, float]
-        | Callable[[float, float, float, float], Sequence[tuple[float, float] | complex]]
+        | Callable[
+            [float, float, float, float], Sequence[tuple[float, float] | complex]
+        ]
         | Sequence[
             Literal["flush", "extended", "round", "smooth"]
             | tuple[float, float]
-            | Callable[[float, float, float, float], Sequence[tuple[float, float] | complex]]
+            | Callable[
+                [float, float, float, float], Sequence[tuple[float, float] | complex]
+            ]
         ] = "flush",
         bend_radius: float | Sequence[float] = 0,
         bend_function: Optional[
-            Callable[[float, float, float, float], Sequence[tuple[float, float] | complex]]
+            Callable[
+                [float, float, float, float], Sequence[tuple[float, float] | complex]
+            ]
         ]
         | Sequence[
-            Callable[[float, float, float, float], Sequence[tuple[float, float] | complex]]
+            Callable[
+                [float, float, float, float], Sequence[tuple[float, float] | complex]
+            ]
         ] = None,
         tolerance: float = 1e-2,
         simple_path: bool = False,
@@ -281,7 +311,9 @@ class FlexPath:
         relative: bool = False,
     ) -> Self: ...
     def mirror(
-        self, p1: tuple[float, float] | complex, p2: tuple[float, float] | complex = (0, 0)
+        self,
+        p1: tuple[float, float] | complex,
+        p2: tuple[float, float] | complex = (0, 0),
     ) -> Self: ...
     def offsets(self) -> numpy.ndarray[Any, numpy.dtype[numpy.float64]]: ...
     def parametric(
@@ -306,8 +338,12 @@ class FlexPath:
         offset: Optional[float] | Sequence[float] = None,
         relative: bool = False,
     ) -> Self: ...
-    def rotate(self, angle: float, center: tuple[float, float] | complex = (0, 0)) -> Self: ...
-    def scale(self, s: float, center: tuple[float, float] | complex = (0, 0)) -> Self: ...
+    def rotate(
+        self, angle: float, center: tuple[float, float] | complex = (0, 0)
+    ) -> Self: ...
+    def scale(
+        self, s: float, center: tuple[float, float] | complex = (0, 0)
+    ) -> Self: ...
     def segment(
         self,
         xy: Sequence[tuple[float, float] | complex] | tuple[float, float] | complex,
@@ -317,7 +353,9 @@ class FlexPath:
     ) -> Self: ...
     def set_bend_function(
         self,
-        functions: Optional[Callable[[float, float, float, float], Sequence[tuple[float, float]]]],
+        functions: Optional[
+            Callable[[float, float, float, float], Sequence[tuple[float, float]]]
+        ],
     ) -> Self: ...
     def set_bend_radius(self, *radii: Optional[float]) -> Self: ...
     def set_datatypes(self, *datatypes: int) -> Self: ...
@@ -332,7 +370,8 @@ class FlexPath:
         self,
         *joins: Literal["natural", "miter", "bevel", "round", "smooth"]
         | Callable[
-            [float, float, float, float, float, float], Sequence[tuple[float, float] | complex]
+            [float, float, float, float, float, float],
+            Sequence[tuple[float, float] | complex],
         ],
     ) -> Self: ...
     def set_layers(self, *layers: int) -> Self: ...
@@ -453,26 +492,39 @@ class Polygon:
     repetition: Repetition
     size: int
     def __init__(
-        self, points: Sequence[tuple[float, float] | complex], layer: int = 0, datatype: int = 0
-    )-> None: ...
+        self,
+        points: Sequence[tuple[float, float] | complex],
+        layer: int = 0,
+        datatype: int = 0,
+    ) -> None: ...
     def apply_repetition(self) -> list[Self]: ...
     def area(self) -> float: ...
     def perimeter(self) -> float: ...
     def bounding_box(self) -> tuple[tuple[float, float], tuple[float, float]]: ...
-    def contain(self, *points: tuple[float, float] | complex) -> bool | tuple[bool, ...]: ...
+    def contain(
+        self, *points: tuple[float, float] | complex
+    ) -> bool | tuple[bool, ...]: ...
     def contain_all(self, *points: tuple[float, float] | complex) -> bool: ...
     def contain_any(self, *points: tuple[float, float] | complex) -> bool: ...
     def copy(self) -> Self: ...
     def delete_gds_property(self, attr: int) -> Self: ...
     def delete_property(self, name: str) -> Self: ...
-    def fillet(self, radius: float | Sequence[float], tolerance: float = 0.01) -> Self: ...
-    def fracture(self, max_points: int = 199, precision: float = 1e-3) -> list[Polygon]: ...
+    def fillet(
+        self, radius: float | Sequence[float], tolerance: float = 0.01
+    ) -> Self: ...
+    def fracture(
+        self, max_points: int = 199, precision: float = 1e-3
+    ) -> list[Polygon]: ...
     def get_gds_property(self, attr: int) -> Optional[str]: ...
     def get_property(self, name: str) -> Optional[list[list[str | bytes | float]]]: ...
     def mirror(
-        self, p1: tuple[float, float] | complex, p2: tuple[float, float] | complex = (0, 0)
+        self,
+        p1: tuple[float, float] | complex,
+        p2: tuple[float, float] | complex = (0, 0),
     ) -> Self: ...
-    def rotate(self, angle: float, center: tuple[float, float] | complex = (0, 0)) -> Self: ...
+    def rotate(
+        self, angle: float, center: tuple[float, float] | complex = (0, 0)
+    ) -> Self: ...
     def scale(
         self, sx: float, sy: float = 0, center: tuple[float, float] | complex = (0, 0)
     ) -> Self: ...
@@ -486,7 +538,7 @@ class Polygon:
         x_reflection: bool = False,
         rotation: float = 0,
         translation: Optional[tuple[float, float] | complex] = None,
-        matrix: Optional[ArrayLike] = None, # type: ignore
+        matrix: Optional[ArrayLike] = None,  # type: ignore
     ) -> Self: ...
     def translate(
         self, dx: float | tuple[float, float] | complex, dy: Optional[float] = None
@@ -495,7 +547,7 @@ class Polygon:
 class RawCell:
     name: str
     size: int
-    def __init__(self, name: str)-> None: ...
+    def __init__(self, name: str) -> None: ...
     def dependencies(self, recursive: bool) -> list[RawCell]: ...
 
 class Reference:
@@ -517,7 +569,7 @@ class Reference:
         columns: int = 1,
         rows: int = 1,
         spacing: Optional[Sequence[float]] = ...,
-    )-> None: ...
+    ) -> None: ...
     def apply_repetition(self) -> list[Self]: ...
     def bounding_box(self) -> tuple[tuple[float, float], tuple[float, float]]: ...
     def convex_hull(self) -> numpy.ndarray[Any, numpy.dtype[numpy.float64]]: ...
@@ -573,7 +625,7 @@ class Repetition:
         offsets: Optional[Sequence[tuple[float, float] | complex]] = None,
         x_offsets: Optional[Sequence[float]] = None,
         y_offsets: Optional[Sequence[float]] = None,
-    )-> None: ...
+    ) -> None: ...
     def get_offsets(self) -> numpy.ndarray[Any, numpy.dtype[numpy.float64]]: ...
 
 class RobustPath:
@@ -581,7 +633,9 @@ class RobustPath:
     ends: tuple[
         Literal["flush", "extended", "round", "smooth"]
         | tuple[float, float]
-        | Callable[[float, float, float, float], Sequence[complex | tuple[float, float]]],
+        | Callable[
+            [float, float, float, float], Sequence[complex | tuple[float, float]]
+        ],
         ...,
     ]
     layers: tuple[int, ...]
@@ -601,18 +655,22 @@ class RobustPath:
         ends: Sequence[
             Literal["flush", "extended", "round", "smooth"]
             | tuple[float, float]
-            | Callable[[float, float, float, float], Sequence[complex | tuple[float, float]]]
+            | Callable[
+                [float, float, float, float], Sequence[complex | tuple[float, float]]
+            ]
         ]
         | Literal["flush", "extended", "round", "smooth"]
         | tuple[float, float]
-        | Callable[[float, float, float, float], Sequence[complex | tuple[float, float]]] = "flush",
+        | Callable[
+            [float, float, float, float], Sequence[complex | tuple[float, float]]
+        ] = "flush",
         tolerance: float = 1e-2,
         max_evals: int = 1000,
         simple_path: bool = False,
         scale_width: bool = True,
         layer: int | list[int] = 0,
         datatype: int | list[int] = 0,
-    )->None: ...
+    ) -> None: ...
     def apply_repetition(self) -> list[Self]: ...
     def arc(
         self,
@@ -624,13 +682,17 @@ class RobustPath:
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         offset: Optional[float]
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
     ) -> Self: ...
     def bezier(
@@ -640,13 +702,17 @@ class RobustPath:
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         offset: Optional[float]
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         relative: bool = False,
     ) -> Self: ...
@@ -659,13 +725,17 @@ class RobustPath:
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         offset: Optional[float]
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         relative: bool = False,
     ) -> Self: ...
@@ -676,13 +746,17 @@ class RobustPath:
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         offset: Optional[float]
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         relative: bool = False,
     ) -> Self: ...
@@ -690,7 +764,9 @@ class RobustPath:
     def delete_property(self, name: str) -> Self: ...
     def get_gds_property(self, attr: int) -> Optional[str]: ...
     def get_property(self, name: str) -> Optional[list[list[str | bytes | float]]]: ...
-    def gradient(self, u: float, from_below: bool = True) -> numpy.ndarray[Any, numpy.dtype[numpy.float64]]: ...
+    def gradient(
+        self, u: float, from_below: bool = True
+    ) -> numpy.ndarray[Any, numpy.dtype[numpy.float64]]: ...
     def horizontal(
         self,
         x: float,
@@ -698,13 +774,17 @@ class RobustPath:
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         offset: Optional[float]
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         relative: bool = False,
     ) -> Self: ...
@@ -721,40 +801,56 @@ class RobustPath:
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         offset: Optional[float]
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         relative: bool = True,
     ) -> Self: ...
     def mirror(
-        self, p1: tuple[float, float] | complex, p2: tuple[float, float] | complex = (0, 0)
+        self,
+        p1: tuple[float, float] | complex,
+        p2: tuple[float, float] | complex = (0, 0),
     ) -> Self: ...
-    def offsets(self, u: float, from_below: bool = True) -> numpy.ndarray[Any, numpy.dtype[numpy.float64]]: ...
+    def offsets(
+        self, u: float, from_below: bool = True
+    ) -> numpy.ndarray[Any, numpy.dtype[numpy.float64]]: ...
     def parametric(
         self,
         path_function: Callable[[float], tuple[float, float] | complex],
-        path_gradient: Optional[Callable[[float], tuple[float, float] | complex]] = None,
+        path_gradient: Optional[
+            Callable[[float], tuple[float, float] | complex]
+        ] = None,
         width: Optional[float]
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         offset: Optional[float]
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         relative: bool = True,
     ) -> Self: ...
     def path_spines(self) -> list[numpy.ndarray[Any, numpy.dtype[numpy.float64]]]: ...
-    def position(self, u: float, from_below: bool = True) -> numpy.ndarray[Any, numpy.dtype[numpy.float64]]: ...
+    def position(
+        self, u: float, from_below: bool = True
+    ) -> numpy.ndarray[Any, numpy.dtype[numpy.float64]]: ...
     def quadratic(
         self,
         xy: Sequence[tuple[float, float] | complex],
@@ -762,13 +858,17 @@ class RobustPath:
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         offset: Optional[float]
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         relative: bool = False,
     ) -> Self: ...
@@ -779,18 +879,26 @@ class RobustPath:
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         offset: Optional[float]
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         relative: bool = False,
     ) -> Self: ...
-    def rotate(self, angle: float, center: tuple[float, float] | complex = (0, 0)) -> Self: ...
-    def scale(self, s: float, center: tuple[float, float] | complex = (0, 0)) -> Self: ...
+    def rotate(
+        self, angle: float, center: tuple[float, float] | complex = (0, 0)
+    ) -> Self: ...
+    def scale(
+        self, s: float, center: tuple[float, float] | complex = (0, 0)
+    ) -> Self: ...
     def segment(
         self,
         xy: tuple[float, float] | complex,
@@ -798,13 +906,17 @@ class RobustPath:
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         offset: Optional[float]
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         relative: bool = False,
     ) -> Self: ...
@@ -839,17 +951,23 @@ class RobustPath:
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         offset: Optional[float]
         | tuple[float, Literal["constant", "linear", "smooth"]]
         | Callable[[float], float]
         | Sequence[
-            float | tuple[float, Literal["constant", "linear", "smooth"]] | Callable[[float], float]
+            float
+            | tuple[float, Literal["constant", "linear", "smooth"]]
+            | Callable[[float], float]
         ] = None,
         relative: bool = False,
     ) -> Self: ...
-    def widths(self, u: float, from_below: bool = True) -> numpy.ndarray[Any, numpy.dtype[numpy.float64]]: ...
+    def widths(
+        self, u: float, from_below: bool = True
+    ) -> numpy.ndarray[Any, numpy.dtype[numpy.float64]]: ...
 
 def all_inside(
     points: Sequence[tuple[float, float] | complex],
@@ -884,7 +1002,7 @@ def boolean(
     datatype: int = 0,
 ) -> list[Polygon]: ...
 def contour(
-    data: ArrayLike, # type: ignore
+    data: ArrayLike,  # type: ignore
     level: int = 0,
     length_scale: float = 1,
     precision: float = 0.01,
@@ -952,7 +1070,9 @@ def read_gds(
     tolerance: float = 0,
     filter: Optional[Iterable[tuple[int, int]]] = None,
 ) -> Library: ...
-def read_oas(infile: str | pathlib.Path, unit: float = 0, tolerance: float = 0) -> Library: ...
+def read_oas(
+    infile: str | pathlib.Path, unit: float = 0, tolerance: float = 0
+) -> Library: ...
 def read_rawcells(infile: str | pathlib.Path) -> dict[str, RawCell]: ...
 def rectangle(
     corner1: tuple[float, float] | complex,

--- a/include/gdstk/flexpath.hpp
+++ b/include/gdstk/flexpath.hpp
@@ -13,6 +13,8 @@ LICENSE file or <http://www.boost.org/LICENSE_1_0.txt>
 
 #include <stdint.h>
 
+#include <optional>
+
 #include "array.hpp"
 #include "curve.hpp"
 #include "oasis.hpp"
@@ -73,7 +75,7 @@ struct FlexPath {
     Repetition repetition;
     Property* properties;
 
-    RaithData raith_data;
+    std::optional<RaithData> raith_data;
 
     // Used by the python interface to store the associated PyObject* (if any).
     // No functions in gdstk namespace should touch this value!

--- a/include/gdstk/raithdata.hpp
+++ b/include/gdstk/raithdata.hpp
@@ -3,6 +3,8 @@
 
 #include <cstdint>
 
+#include "utils.hpp"
+
 namespace gdstk {
 
 #pragma pack(push, 1)
@@ -43,8 +45,9 @@ struct RaithData {
 
     void copy_from(const RaithData& raith_data);
 
-    PXXData to_pxxdata() const;
-    void from_pxxdata(PXXData const& pxxdata);
+    PXXData to_pxxdata(double scaling);
+    ErrorCode to_gds(FILE* out, double scaling);
+    static RaithData from_pxxdata(PXXData const& pxxdata);
 };
 
 }  // namespace gdstk

--- a/python/flexpath_object.cpp
+++ b/python/flexpath_object.cpp
@@ -2295,15 +2295,19 @@ int flexpath_object_set_repetition(FlexPathObject* self, PyObject* arg, void*) {
 }
 
 static PyObject* flexpath_object_get_raith_data(FlexPathObject* self, void*) {
+    if (!self->flexpath->raith_data.has_value()) {
+        Py_RETURN_NONE;
+    }
+
     RaithDataObject* obj = PyObject_New(RaithDataObject, &raithdata_object_type);
     obj = (RaithDataObject*)PyObject_Init((PyObject*)obj, &raithdata_object_type);
-    obj->raith_data.copy_from(self->flexpath->raith_data);
+    obj->raith_data.copy_from(self->flexpath->raith_data.value());
     return (PyObject*)obj;
 }
 
 int flexpath_object_set_raith_data(FlexPathObject* self, PyObject* arg, void*) {
     if (arg == Py_None) {
-        self->flexpath->raith_data.clear();
+        self->flexpath->raith_data.reset();
         return 0;
     }
     if (!RaithDataObject_Check(arg)) {
@@ -2311,7 +2315,10 @@ int flexpath_object_set_raith_data(FlexPathObject* self, PyObject* arg, void*) {
         return -1;
     }
     RaithDataObject* raith_data_obj = (RaithDataObject*)arg;
-    self->flexpath->raith_data.copy_from(raith_data_obj->raith_data);
+
+    self->flexpath->raith_data.emplace();
+    self->flexpath->raith_data->copy_from(raith_data_obj->raith_data);
+
     return 0;
 }
 

--- a/python/flexpath_object.cpp
+++ b/python/flexpath_object.cpp
@@ -2315,10 +2315,8 @@ int flexpath_object_set_raith_data(FlexPathObject* self, PyObject* arg, void*) {
         return -1;
     }
     RaithDataObject* raith_data_obj = (RaithDataObject*)arg;
-
     self->flexpath->raith_data.emplace();
     self->flexpath->raith_data->copy_from(raith_data_obj->raith_data);
-
     return 0;
 }
 

--- a/python/raithdata_object.cpp
+++ b/python/raithdata_object.cpp
@@ -8,7 +8,8 @@ static PyObject* raithdata_object_str(RaithDataObject* self) {
         ", grating_type=%" PRIu32 ", dots_per_cycle=%" PRIu32 ")",
         raith_data.base_cell_name ? raith_data.base_cell_name : "", raith_data.dwelltime_selection,
         raith_data.pitch_parallel_to_path, raith_data.pitch_perpendicular_to_path,
-        raith_data.pitch_scale, raith_data.periods, raith_data.grating_type, raith_data.dots_per_cycle);
+        raith_data.pitch_scale, raith_data.periods, raith_data.grating_type,
+        raith_data.dots_per_cycle);
     return PyUnicode_FromString(buffer);
 }
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1075,7 +1075,10 @@ Library read_gds(const char* filename, double unit, double tolerance, const Set<
                 if (path) {
                     PXXData pxxdata;
                     memcpy(&pxxdata, buffer + 4, record_length);
-                    path->raith_data.from_pxxdata(pxxdata);
+
+                    RaithData new_raith_data = RaithData::from_pxxdata(pxxdata);
+
+                    path->raith_data = std::move(new_raith_data);
                 }
                 break;
             case GdsiiRecord::SREF:
@@ -1208,9 +1211,12 @@ Library read_gds(const char* filename, double unit, double tolerance, const Set<
                     reference->type = ReferenceType::Name;
                 } else if (path) {
                     if (str[data_length - 1] == 0) data_length--;
-                    path->raith_data.base_cell_name = (char*)allocate(data_length + 1);
-                    memcpy(path->raith_data.base_cell_name, str, data_length);
-                    path->raith_data.base_cell_name[data_length] = 0;
+
+                    RaithData& raith_data = path->raith_data.value();
+
+                    raith_data.base_cell_name = (char*)allocate(data_length + 1);
+                    memcpy(raith_data.base_cell_name, str, data_length);
+                    raith_data.base_cell_name[data_length] = 0;
                 }
                 break;
             case GdsiiRecord::COLROW:

--- a/src/raithdata.cpp
+++ b/src/raithdata.cpp
@@ -33,12 +33,12 @@ void RaithData::copy_from(const RaithData& raith_data) {
     if (raith_data.base_cell_name) base_cell_name = copy_string(raith_data.base_cell_name, NULL);
 }
 
-PXXData RaithData::to_pxxdata() const {
+PXXData RaithData::to_pxxdata(double scaling) {
     PXXData pd{};
     pd.dwelltime_selection = dwelltime_selection;
-    pd.pitch_parallel_to_path = pitch_parallel_to_path;
-    pd.pitch_perpendicular_to_path = pitch_perpendicular_to_path;
-    pd.pitch_scale = pitch_scale;
+    pd.pitch_parallel_to_path = pitch_parallel_to_path * scaling;
+    pd.pitch_perpendicular_to_path = pitch_perpendicular_to_path * scaling;
+    pd.pitch_scale = pitch_scale * scaling;
     pd.periods = periods;
     pd.grating_type = grating_type;
     pd.dots_per_cycle = dots_per_cycle;
@@ -47,14 +47,38 @@ PXXData RaithData::to_pxxdata() const {
     return pd;
 }
 
-void RaithData::from_pxxdata(PXXData const& pxxdata) {
-    pitch_parallel_to_path = pxxdata.pitch_parallel_to_path;
-    pitch_perpendicular_to_path = pxxdata.pitch_perpendicular_to_path;
-    pitch_scale = pxxdata.pitch_scale;
-    periods = pxxdata.periods;
-    grating_type = pxxdata.grating_type;
-    dots_per_cycle = pxxdata.dots_per_cycle;
-    dwelltime_selection = pxxdata.dwelltime_selection;
+ErrorCode RaithData::to_gds(FILE* out, double scaling) {
+    ErrorCode error_code = ErrorCode::NoError;
+
+    uint64_t len = base_cell_name ? strlen(base_cell_name) : 0;
+    if (len % 2) len++;
+    uint16_t sname_start[] = {(uint16_t)(4 + len), 0x1206};
+    big_endian_swap16(sname_start, COUNT(sname_start));
+    fwrite(sname_start, sizeof(uint16_t), COUNT(sname_start), out);
+
+    fwrite(base_cell_name, 1, len, out);
+
+    PXXData pxxdata = to_pxxdata(scaling);
+    pxxdata.little_endian_swap();
+
+    uint16_t buffer_pxx[] = {(uint16_t)(4 + sizeof(PXXData)), 0x6206};
+    big_endian_swap16(buffer_pxx, COUNT(buffer_pxx));
+    fwrite(buffer_pxx, sizeof(uint16_t), COUNT(buffer_pxx), out);
+    fwrite(&pxxdata, 1, sizeof(PXXData), out);
+
+    return error_code;
+}
+
+RaithData RaithData::from_pxxdata(PXXData const& pxxdata) {
+    RaithData data;
+    data.pitch_parallel_to_path = pxxdata.pitch_parallel_to_path;
+    data.pitch_perpendicular_to_path = pxxdata.pitch_perpendicular_to_path;
+    data.pitch_scale = pxxdata.pitch_scale;
+    data.periods = pxxdata.periods;
+    data.grating_type = pxxdata.grating_type;
+    data.dots_per_cycle = pxxdata.dots_per_cycle;
+    data.dwelltime_selection = pxxdata.dwelltime_selection;
+    return data;
 }
 
 }  // namespace gdstk

--- a/src/raithdata.cpp
+++ b/src/raithdata.cpp
@@ -29,8 +29,7 @@ void RaithData::copy_from(const RaithData& raith_data) {
     grating_type = raith_data.grating_type;
     dots_per_cycle = raith_data.dots_per_cycle;
     dwelltime_selection = raith_data.dwelltime_selection;
-    if (base_cell_name) free_allocation(base_cell_name);
-    if (raith_data.base_cell_name) base_cell_name = copy_string(raith_data.base_cell_name, NULL);
+    base_cell_name = copy_string(raith_data.base_cell_name, NULL);
 }
 
 PXXData RaithData::to_pxxdata(double scaling) {

--- a/tests/flexpath_test.py
+++ b/tests/flexpath_test.py
@@ -89,7 +89,9 @@ def test_transforms(proof_cells):
             path0.copy().scale(-2, (-1, 0)),
             path0.copy().rotate(numpy.pi / 2, (2, 1)).translate(0.2, -0.3),
         ]
-        assert_same_shape(proof_cells[f"FlexPath:scale_width_{scale_width}"].polygons, paths)
+        assert_same_shape(
+            proof_cells[f"FlexPath:scale_width_{scale_width}"].polygons, paths
+        )
 
 
 def test_points():
@@ -99,12 +101,20 @@ def test_points():
     numpy.testing.assert_array_equal(path.offsets(), [[0], [0], [0], [1]])
     path_spines = path.path_spines()
     assert len(path_spines) == 1
-    numpy.testing.assert_array_equal(path_spines[0], [[0, 0], [0, 10], [10, 10], [11, 0]])
+    numpy.testing.assert_array_equal(
+        path_spines[0], [[0, 0], [0, 10], [10, 10], [11, 0]]
+    )
 
-    path = gdstk.FlexPath((0j, 10j), [2, 2], 2).horizontal(10, 2, 1).vertical(0, 1, [-2, 1])
+    path = (
+        gdstk.FlexPath((0j, 10j), [2, 2], 2)
+        .horizontal(10, 2, 1)
+        .vertical(0, 1, [-2, 1])
+    )
     numpy.testing.assert_array_equal(path.spine(), [[0, 0], [0, 10], [10, 10], [10, 0]])
     numpy.testing.assert_array_equal(path.widths(), [[2, 2], [2, 2], [2, 2], [1, 1]])
-    numpy.testing.assert_array_equal(path.offsets(), [[-1, 1], [-1, 1], [-0.5, 0.5], [-2, 1]])
+    numpy.testing.assert_array_equal(
+        path.offsets(), [[-1, 1], [-1, 1], [-0.5, 0.5], [-2, 1]]
+    )
     path_spines = path.path_spines()
     assert len(path_spines) == 2
 
@@ -154,15 +164,18 @@ def test_deepcopy():
 def test_raith_data():
     path = gdstk.FlexPath(0j, 2)
     raith_data = path.raith_data
-    assert raith_data is not path.raith_data
-    assert raith_data.base_cell_name is None
+    assert raith_data is None
+    raith_data = gdstk.RaithData("CELL", 1, 2, 3, 4, 5, 6, 7)
 
-    path.raith_data = gdstk.RaithData("CELL", 1, 2, 3, 4, 5, 6, 7)
-    assert path.raith_data.base_cell_name == "CELL"
-    assert path.raith_data.dwelltime_selection == 1
-    assert path.raith_data.pitch_parallel_to_path == 2
-    assert path.raith_data.pitch_perpendicular_to_path == 3
-    assert path.raith_data.pitch_scale == 4
-    assert path.raith_data.periods == 5
-    assert path.raith_data.grating_type == 6
-    assert path.raith_data.dots_per_cycle == 7
+    path.raith_data = raith_data
+    path_raith_data = path.raith_data
+    assert path_raith_data is not None
+
+    assert path_raith_data.base_cell_name == "CELL"
+    assert path_raith_data.dwelltime_selection == 1
+    assert path_raith_data.pitch_parallel_to_path == 2
+    assert path_raith_data.pitch_perpendicular_to_path == 3
+    assert path_raith_data.pitch_scale == 4
+    assert path_raith_data.periods == 5
+    assert path_raith_data.grating_type == 6
+    assert path_raith_data.dots_per_cycle == 7

--- a/tests/test_raith_data.py
+++ b/tests/test_raith_data.py
@@ -1,0 +1,12 @@
+import gdstk
+
+
+def test_init():
+    raith_data = gdstk.RaithData("CELL", 1, 2, 3, 4, 5, 6, 7)
+    assert raith_data.dwelltime_selection == 1
+    assert raith_data.pitch_parallel_to_path == 2
+    assert raith_data.pitch_perpendicular_to_path == 3
+    assert raith_data.pitch_scale == 4
+    assert raith_data.periods == 5
+    assert raith_data.grating_type == 6
+    assert raith_data.dots_per_cycle == 7


### PR DESCRIPTION
Fix for #270.

Changes:
- updated type hints so raith_data is optional and its attributes are immutable
- Made FlexPath.raith_data in c++ `optional<RaithData>`
- moved raith to_gds functionality to the `RaithData` struct
- (accidentally) reformatted .pyi file (I can change this back if this is an issue)
- add tests for `RaithData`
- update tests for `FlexPath.rath_data`