### PR TITLE
Correct property value check in `remove_gds_property()`

### DIFF
--- a/src/property.cpp
+++ b/src/property.cpp
@@ -277,7 +277,7 @@ bool remove_gds_property(Property*& properties, uint16_t attribute) {
     }
     Property* property = properties;
     while (property->next &&
-           (!is_gds_property(property->next) || property->value->unsigned_integer != attribute))
+           (!is_gds_property(property->next) || property->next->value->unsigned_integer != attribute))
         property = property->next;
     if (property->next) {
         Property* rem = property->next;

--- a/tests/property_test.py
+++ b/tests/property_test.py
@@ -68,3 +68,72 @@ def test_properties():
             ["TWO", -2.3e-4, b"two"],
             ["Three", b"\xFF\xEE", 0],
         ]
+
+
+def test_delete_gds_property():
+    def create_props(obj) -> gdstk.Reference:
+        obj.set_gds_property(100, "bar")
+        obj.set_gds_property(101, "baz")
+        obj.set_gds_property(102, "quux")
+
+        assert obj.properties == [
+            ["S_GDS_PROPERTY", 102, b"quux\x00"],
+            ["S_GDS_PROPERTY", 101, b"baz\x00"],
+            ["S_GDS_PROPERTY", 100, b"bar\x00"],
+        ]
+
+        return obj
+
+    for obj in (
+        gdstk.FlexPath(0j, 2),
+        gdstk.Label("foo", (0, 0)),
+        gdstk.rectangle((0, 0), (1, 1)),
+        gdstk.Reference("foo"),
+        gdstk.RobustPath((0.5, 50), 0),
+    ):
+        create_props(obj)
+        obj.delete_gds_property(102)
+
+        assert obj.get_gds_property(100) == "bar"
+        assert obj.get_gds_property(101) == "baz"
+        assert obj.get_gds_property(102) is None
+        assert obj.properties == [
+            ["S_GDS_PROPERTY", 101, b"baz\x00"],
+            ["S_GDS_PROPERTY", 100, b"bar\x00"],
+        ]
+
+    for obj in (
+        gdstk.FlexPath(0j, 2),
+        gdstk.Label("foo", (0, 0)),
+        gdstk.rectangle((0, 0), (1, 1)),
+        gdstk.Reference("foo"),
+        gdstk.RobustPath((0.5, 50), 0),
+    ):
+        create_props(obj)
+        obj.delete_gds_property(101)
+
+        assert obj.get_gds_property(100) == "bar"
+        assert obj.get_gds_property(101) is None
+        assert obj.get_gds_property(102) == "quux"
+        assert obj.properties == [
+            ["S_GDS_PROPERTY", 102, b"quux\x00"],
+            ["S_GDS_PROPERTY", 100, b"bar\x00"],
+        ]
+
+    for obj in (
+        gdstk.FlexPath(0j, 2),
+        gdstk.Label("foo", (0, 0)),
+        gdstk.rectangle((0, 0), (1, 1)),
+        gdstk.Reference("foo"),
+        gdstk.RobustPath((0.5, 50), 0),
+    ):
+        create_props(obj)
+        obj.delete_gds_property(100)
+
+        assert obj.get_gds_property(100) is None
+        assert obj.get_gds_property(101) == "baz"
+        assert obj.get_gds_property(102) == "quux"
+        assert obj.properties == [
+            ["S_GDS_PROPERTY", 102, b"quux\x00"],
+            ["S_GDS_PROPERTY", 101, b"baz\x00"],
+        ]


### PR DESCRIPTION
When there's more than one property set on an object, the `remove_gds_property()` function must traverse the `Property` linked list to find the item with the desired property number. However, the traversal checks the current property's value rather than that of `property->next`, causing the failure described in #275.

This PR updates the value check and adds a unit test to cover this case.

Closes https://github.com/heitzmann/gdstk/issues/275.