### PR TITLE
Return error when attempting to serialize an empty path

### DIFF
--- a/include/gdstk/utils.hpp
+++ b/include/gdstk/utils.hpp
@@ -69,6 +69,7 @@ enum struct ErrorCode {
     NoError = 0,
     // Warnings
     BooleanError,
+    EmptyPath,
     IntersectionNotFound,
     MissingReference,
     UnsupportedRecord,

--- a/python/gdstk_module.cpp
+++ b/python/gdstk_module.cpp
@@ -51,6 +51,9 @@ static int return_error(ErrorCode error_code) {
         case ErrorCode::NoError:
             return 0;
         // Warnings
+        case ErrorCode::EmptyPath:
+            if (PyErr_WarnEx(PyExc_RuntimeWarning, "Empty path.", 1) != 0) return -1;
+            return 0;
         case ErrorCode::MissingReference:
             if (PyErr_WarnEx(PyExc_RuntimeWarning, "Missing reference.", 1) != 0) return -1;
             return 0;

--- a/src/flexpath.cpp
+++ b/src/flexpath.cpp
@@ -239,7 +239,7 @@ void FlexPath::remove_overlapping_points() {
 
 ErrorCode FlexPath::to_polygons(bool filter, Tag tag, Array<Polygon*>& result) {
     remove_overlapping_points();
-    if (spine.point_array.count < 2) return ErrorCode::NoError;
+    if (spine.point_array.count < 2) return ErrorCode::EmptyPath;
 
     const Array<Vec2> spine_points = spine.point_array;
     uint64_t curve_size_guess = spine_points.count * 2 + 4;
@@ -774,7 +774,7 @@ ErrorCode FlexPath::to_gds(FILE* out, double scaling) {
 
     remove_overlapping_points();
 
-    if (spine.point_array.count < 2) return error_code;
+    if (spine.point_array.count < 2) return ErrorCode::EmptyPath;
 
     uint16_t buffer_end[] = {4, 0x1100};
     big_endian_swap16(buffer_end, COUNT(buffer_end));
@@ -918,7 +918,7 @@ ErrorCode FlexPath::to_oas(OasisStream& out, OasisState& state) {
 
     remove_overlapping_points();
 
-    if (spine.point_array.count < 2) return error_code;
+    if (spine.point_array.count < 2) return ErrorCode::EmptyPath;
 
     bool has_repetition = repetition.get_count() > 1;
 


### PR DESCRIPTION
As described in https://github.com/heitzmann/gdstk/pull/278#issuecomment-2495198950, this PR returns an error code when an empty `FlexPath` is detected during serialization or when generating polygons. For Python callers, a [`RuntimeWarning`](https://docs.python.org/3/library/exceptions.html#RuntimeWarning) is raised, matching what occurs when missing references or invalid repetitions are encountered.

Because the tolerance value is stored internally to each `FlexPath` though, writing a path to a library with a `precision` value which is too large to represent that path does not generate an error code or warning. Callers will still need to be cautious when copying objects between libraries with differing `precision`s.