### PR TITLE
Add default parameters to library I/O functions

### DIFF
--- a/include/gdstk/library.hpp
+++ b/include/gdstk/library.hpp
@@ -170,8 +170,8 @@ struct LibraryInfo {
 // paths in the library.  If shape_tags is not empty, only shapes in those
 // tags will be imported.  If not NULL, any errors will be reported through
 // error_code.
-Library read_gds(const char* filename, double unit, double tolerance, const Set<Tag>* shape_tags,
-                 ErrorCode* error_code);
+Library read_gds(const char* filename, double unit = 0, double tolerance = 0, const Set<Tag>* shape_tags = nullptr,
+                 ErrorCode* error_code = nullptr);
 
 // Read the contents of an OASIS file into a new library.  If unit is not zero,
 // the units in the file are converted (all elements are properly scaled to the
@@ -179,9 +179,9 @@ Library read_gds(const char* filename, double unit, double tolerance, const Set<
 // paths in the library and for the creation of circles.  If shape_tags is not
 // empty, only shapes in those tags will be imported.  If not NULL, any errors
 // will be reported through error_code.
-Library read_oas(const char* filename, double unit,
-                 double tolerance,  // TODO: const Set<Tag>* shape_tags,
-                 ErrorCode* error_code);
+Library read_oas(const char* filename, double unit = 0,
+                 double tolerance = 0,  // TODO: const Set<Tag>* shape_tags,
+                 ErrorCode* error_code = nullptr);
 
 // Read the unit and precision of a GDSII file and return in the respective
 // arguments.
@@ -190,7 +190,7 @@ ErrorCode gds_units(const char* filename, double& unit, double& precision);
 // Get/set the timestamps in the GDSII file.  If timestamp is not NULL, set the
 // timestamps of the file.  The main library timestamp before any modification
 // is returned.
-tm gds_timestamp(const char* filename, const tm* new_timestamp, ErrorCode* error_code);
+tm gds_timestamp(const char* filename, const tm* new_timestamp = nullptr, ErrorCode* error_code = nullptr);
 
 // Gather information about the GDSII file. Return argument info must be
 // properly initialized.
@@ -205,7 +205,7 @@ ErrorCode oas_precision(const char* filename, double& precision);
 // If not NULL, any errors will be reported through error_code.  If the file
 // has no checksum data, signature will be set to zero and error_code to
 // ErrorCode::ChecksumError if they are not NULL.
-bool oas_validate(const char* filename, uint32_t* signature, ErrorCode* error_code);
+bool oas_validate(const char* filename, uint32_t* signature = nullptr, ErrorCode* error_code = nullptr);
 
 // TODO: Gather information about file
 // ErrorCode oas_info(const char* filename, LibraryInfo& info);


### PR DESCRIPTION
Fixes #298

## Changes
Added default parameters to 4 functions in `include/gdstk/library.hpp`:
- `read_gds()`: `tolerance`, `shape_tags`, `error_code` now optional
- `read_oas()`: `tolerance`, `error_code` now optional  
- `gds_timestamp()`: `new_timestamp`, `error_code` now optional
- `oas_validate()`: `signature`, `error_code` now optional

## Why
Documented C++ examples failed to compile because function signatures required all parameters explicitly. These changes allow the documented simplified calling patterns to work.

## Details
- All defaults match documented behavior and implementation expectations
- 100% backward compatible—existing code with explicit parameters still works
